### PR TITLE
Minor bugfixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,0 @@
-TESTS = test/*.js
-test:
-	mocha --timeout 5000 --check-leaks --reporter spec $(TESTS)
-
-.PHONY: test

--- a/README.md
+++ b/README.md
@@ -1,17 +1,21 @@
 # jira2md
 
 ## JIRA to MarkDown text format converter
+
 Convert from JIRA text formatting to GitHub Flavored MarkDown and back again. Also allows for both to be converted to HTML.
 
 ## Credits
+
 This module was heavily inspired by the J2M project by Fokke Zandbergen (http://j2m.fokkezb.nl/). Major credit to Fokke (and other contributors) for establishing a lot of the fundamental RexExp patterns for this module to work.
 
 ## Installation
-```
+
+```sh
 npm install jira2md
 ```
 
 ## Supported Conversions
+
 NOTE: All conversion work bi-directionally (from jira to markdown and back again).
 
 * Headers (H1-H6)
@@ -41,7 +45,7 @@ NOTE: All conversion work bi-directionally (from jira to markdown and back again
 
 We'll refer to this as the `md` variable in the examples below.
 
-```
+```md
 **Some bold things**
 *Some italic stuff*
 ## H2
@@ -52,7 +56,7 @@ We'll refer to this as the `md` variable in the examples below.
 
 We'll refer to this as the `jira` variable in the examples below.
 
-```
+```jira
 *Some bold things**
 _Some italic stuff_
 h2. H2

--- a/README.md
+++ b/README.md
@@ -2,16 +2,17 @@
 
 ## JIRA to MarkDown text format converter
 
-Convert from JIRA text formatting to GitHub Flavored MarkDown and back again. Also allows for both to be converted to HTML.
+Convert from JIRA text formatting to GitHub Flavored Markdown and back again. Also allows for both to be converted to HTML.
 
 ## Credits
 
-This module was heavily inspired by the J2M project by Fokke Zandbergen (http://j2m.fokkezb.nl/). Major credit to Fokke (and other contributors) for establishing a lot of the fundamental RexExp patterns for this module to work.
+This module was heavily inspired by the [J2M project by Fokke Zandbergen](http://j2m.fokkezb.nl/).
+Major credit to Fokke (and other contributors) for establishing a lot of the fundamental RexExp patterns for this module to work.
 
 ## Installation
 
 ```sh
-npm install jira2md
+npm install @kmatthews/jira2md
 ```
 
 ## Supported Conversions
@@ -66,9 +67,9 @@ h2. H2
 
 ```javascript
 // Include the module
-var j2m = require('jira2md');
+var j2m = require('jira2md'); or import jira2md from 'jira2md';
 
-// If converting from Mardown to Jira Wiki Syntax:
+// If converting from Markdown to Jira Wiki Syntax:
 var jira = j2m.to_jira(md);
 
 // If converting from Jira Wiki Syntax to Markdown:
@@ -80,3 +81,9 @@ var html = j2m.md_to_html(md);
 // If converting from JIRA Wiki Syntax to HTML:
 var html = j2m.jira_to_html(jira);
 ```
+
+### FAQ
+
+#### Q. Why doesn't this module support conversion of inline markdown?
+
+A. Jira doesn't support inline code formatting, so the best we can do is to keep the backticks in place.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ NOTE: All conversion work bi-directionally (from jira to markdown and back again
 * Tables (thanks to erykwarren)
 * Panels (thanks to erykwarren)
 
-
 ## How to Use
 
 ### Markdown String

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ var html = j2m.md_to_html(md);
 var html = j2m.jira_to_html(jira);
 ```
 
+### Running tests
+
+You can run `yarn test` or `npm test`
+
 ### FAQ
 
 #### Q. Why doesn't this module support conversion of inline markdown?

--- a/index.js
+++ b/index.js
@@ -15,134 +15,134 @@ J2M.prototype.jira_to_html = function(str) {
 };
 
 J2M.prototype.to_markdown = function(str) {
-    return str
-        // Ordered Lists
-        .replace(/^[ \t]*(\*+)\s+/gm, function(match, stars) {
-            return Array(stars.length).join("  ") + '* ';
-        })
-        // Un-ordered lists
-        .replace(/^[ \t]*(#+)\s+/gm, function(match, nums) {
-            return Array(nums.length).join("  ") + '1. ';
-        })
-        // Headers 1-6
-        .replace(/^h([0-6])\.(.*)$/gm, function (match, level, content) {
-            return Array(parseInt(level) + 1).join('#') + content;
-        })
-        // Bold
-        .replace(/\*(\S.*)\*/g, '**$1**')
-        // Italic
-        .replace(/\_(\S.*)\_/g, '*$1*')
-        // Monospaced text
-        .replace(/\{\{([^}]+)\}\}/g, '`$1`')
-        // Citations (buggy)
-        //.replace(/\?\?((?:.[^?]|[^?].)+)\?\?/g, '<cite>$1</cite>')
-        // Inserts
-        .replace(/\+([^+]*)\+/g, '<ins>$1</ins>')
-        // Superscript
-        .replace(/\^([^^]*)\^/g, '<sup>$1</sup>')
-        // Subscript
-        .replace(/~([^~]*)~/g, '<sub>$1</sub>')
-        // Strikethrough
-        .replace(/(\s|^)+-(\S+.*?\S)-+/g, '$1~~$2~~')
-        // Code Block
-        .replace(/\{code(:([a-z]+))?([:|]?(title|borderStyle|borderColor|borderWidth|bgColor|titleBGColor)=.+?)*\}([^]*)\{code\}/gm, '```$2$5```')
-        // Pre-formatted text
-        .replace(/{noformat}/g, '```')
-        // Un-named Links
-        .replace(/\[([^|]+)\]/g, '<$1>')
-        // Named Links
-        .replace(/\[(.+?)\|(.+)\]/g, '[$1]($2)')
-        // Single Paragraph Blockquote
-        .replace(/^bq\.\s+/gm, '> ')
-        // Remove color: unsupported in md
-        .replace(/\{color:[^}]+\}([^]*)\{color\}/gm, '$1')
-        // panel into table
-        .replace(/\{panel:title=([^}]*)\}\n?([^]*?)\n?\{panel\}/gm, '\n| $1 |\n| --- |\n| $2 |')
-        // table header
-        .replace(/^[ \t]*((?:\|\|.*?)+\|\|)[ \t]*$/gm, function (match, headers) {
-            const singleBarred =  headers.replace(/\|\|/g,'|');
-            return '\n' + singleBarred + '\n' + singleBarred.replace(/\|[^|]+/g, '| --- ');
-        })
-        // remove leading-space of table headers and rows
-        .replace(/^[ \t]*\|/gm, '|');
+  return str
+    // Ordered Lists
+    .replace(/^[ \t]*(\*+)\s+/gm, function(match, stars) {
+      return Array(stars.length).join("  ") + '* ';
+    })
+    // Un-ordered lists
+    .replace(/^[ \t]*(#+)\s+/gm, function(match, nums) {
+      return Array(nums.length).join("  ") + '1. ';
+    })
+    // Headers 1-6
+    .replace(/^h([0-6])\.(.*)$/gm, function (match, level, content) {
+      return Array(parseInt(level) + 1).join('#') + content;
+    })
+    // Bold
+    .replace(/\*(\S.*)\*/g, '**$1**')
+    // Italic
+    .replace(/\_(\S.*)\_/g, '*$1*')
+    // Monospaced text
+    .replace(/\{\{([^}]+)\}\}/g, '`$1`')
+    // Citations (buggy)
+    //.replace(/\?\?((?:.[^?]|[^?].)+)\?\?/g, '<cite>$1</cite>')
+    // Inserts
+    .replace(/\+([^+]*)\+/g, '<ins>$1</ins>')
+    // Superscript
+    .replace(/\^([^^]*)\^/g, '<sup>$1</sup>')
+    // Subscript
+    .replace(/~([^~]*)~/g, '<sub>$1</sub>')
+    // Strikethrough
+    .replace(/(\s|^)+-(\S+.*?\S)-+/g, '$1~~$2~~')
+    // Code Block
+    .replace(/\{code(:([a-z]+))?([:|]?(title|borderStyle|borderColor|borderWidth|bgColor|titleBGColor)=.+?)*\}([^]*)\{code\}/gm, '```$2$5```')
+    // Pre-formatted text
+    .replace(/{noformat}/g, '```')
+    // Un-named Links
+    .replace(/\[([^|]+)\]/g, '<$1>')
+    // Named Links
+    .replace(/\[(.+?)\|(.+)\]/g, '[$1]($2)')
+    // Single Paragraph Blockquote
+    .replace(/^bq\.\s+/gm, '> ')
+    // Remove color: unsupported in md
+    .replace(/\{color:[^}]+\}([^]*)\{color\}/gm, '$1')
+    // panel into table
+    .replace(/\{panel:title=([^}]*)\}\n?([^]*?)\n?\{panel\}/gm, '\n| $1 |\n| --- |\n| $2 |')
+    // table header
+    .replace(/^[ \t]*((?:\|\|.*?)+\|\|)[ \t]*$/gm, function (match, headers) {
+      const singleBarred =  headers.replace(/\|\|/g,'|');
+      return '\n' + singleBarred + '\n' + singleBarred.replace(/\|[^|]+/g, '| --- ');
+    })
+    // remove leading-space of table headers and rows
+    .replace(/^[ \t]*\|/gm, '|');
 
 };
 
 J2M.prototype.to_jira = function(str) {
-    const map = {
-      //cite: '??',
-      del: '-',
-      ins: '+',
-      sup: '^',
-      sub: '~'
-    };
+  const map = {
+    //cite: '??',
+    del: '-',
+    ins: '+',
+    sup: '^',
+    sub: '~'
+  };
 
-    return str
-        // Bold, Italic, and Combined (bold+italic)
-        .replace(/([*_]+)(\S.*?)\1/g, function (match,wrapper,content) {
-            switch (wrapper.length) {
-                case 1: return '_' + content + '_';
-                case 2: return '*' + content + '*';
-                case 3: return '_*' + content + '*_';
-                default: return wrapper + content * wrapper;
-            }
-         })
-         // All Headers (# format)
-         .replace(/^([#]+)(.*?)$/gm, function (match,level,content) {
-             return 'h' + level.length + '.' + content;
-         })
-         // Headers (H1 and H2 underlines)
-         .replace(/^(.*?)\n([=-]+)$/gm, function (match,content,level) {
-             return 'h' + (level[0] === '=' ? 1 : 2) + '. ' + content;
-         })
-        // Ordered lists
-        .replace(/^([ \t]*)\d+\.\s+/gm, function(match, spaces) {
-            return Array(Math.floor(spaces.length/2 + 1)).join("#") + '# ';
-        })
-        // Un-Ordered Lists
-        .replace(/^([ \t]*)\*\s+/gm, function(match, spaces) {
-            return Array(Math.floor(spaces.length/2 + 1)).join("*") + '* ';
-        })
-        // Headers (h1 or h2) (lines "underlined" by ---- or =====)
-        // Citations, Inserts, Subscripts, Superscripts, and Strikethroughs
-        .replace(new RegExp('<(' + Object.keys(map).join('|') + ')>(.*?)<\/\\1>', 'g'), function (match,from,content) {
-            const to = map[from];
-            return to + content + to;
-        })
-        // Other kind of strikethrough
-        .replace(/\s+~~(.*?)~~\s+/g, ' -$1- ')
-        // Named/Un-Named Code Block
-        .replace(/`{3,}(\w+)?((?:\n|[^`])+)`{3,}/g, function(match, synt, content) {
-            const code = '{code';
-            if (synt) code += ':' + synt;
-            return code + '}' + content + '{code}';
-        })
-        // Inline-Preformatted Text
-        .replace(/`([^`]+)`/g, '{{$1}}')
-        // Named Link
-        .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '[$1|$2]')
-        // Un-Named Link
-        .replace(/<([^>]+)>/g, '[$1]')
-        // Single Paragraph Blockquote
-        .replace(/^>/gm, 'bq.')
-        // tables
-        .replace(/^\n((?:\|.*?)+\|)[ \t]*\n((?:\|\s*?\-{3,}\s*?)+\|)[ \t]*\n((?:(?:\|.*?)+\|[ \t]*\n)*)$/gm,
-                 function (match, headerLine, separatorLine, rowstr) {
-                     const headers = headerLine.match(/[^|]+(?=\|)/g);
-                     const separators = separatorLine.match(/[^|]+(?=\|)/g);
-                     if (headers.length !== separators.length) {
-                         return match;
-                     }
-                     const rows = rowstr.split('\n');
-                     if (rows.length === 1 + 1 && headers.length === 1) {
-                         // panel
-                         return '{panel:title=' + headers[0].trim() + '}\n' +
-                             rowstr.replace(/^\|(.*)[ \t]*\|/, '$1').trim() +
-                             '\n{panel}\n';
-                     } else {
-                         return '||' + headers.join('||') + '||\n' + rowstr;
-                     }
-                 });
+  return str
+    // Bold, Italic, and Combined (bold+italic)
+    .replace(/([*_]+)(\S.*?)\1/g, function (match,wrapper,content) {
+      switch (wrapper.length) {
+        case 1: return '_' + content + '_';
+        case 2: return '*' + content + '*';
+        case 3: return '_*' + content + '*_';
+        default: return wrapper + content * wrapper;
+      }
+    })
+    // All Headers (# format)
+    .replace(/^([#]+)(.*?)$/gm, function (match,level,content) {
+      return 'h' + level.length + '.' + content;
+    })
+    // Headers (H1 and H2 underlines)
+    .replace(/^(.*?)\n([=-]+)$/gm, function (match,content,level) {
+      return 'h' + (level[0] === '=' ? 1 : 2) + '. ' + content;
+    })
+    // Ordered lists
+    .replace(/^([ \t]*)\d+\.\s+/gm, function(match, spaces) {
+      return Array(Math.floor(spaces.length/2 + 1)).join("#") + '# ';
+    })
+    // Un-Ordered Lists
+    .replace(/^([ \t]*)\*\s+/gm, function(match, spaces) {
+      return Array(Math.floor(spaces.length/2 + 1)).join("*") + '* ';
+    })
+    // Headers (h1 or h2) (lines "underlined" by ---- or =====)
+    // Citations, Inserts, Subscripts, Superscripts, and Strikethroughs
+    .replace(new RegExp('<(' + Object.keys(map).join('|') + ')>(.*?)<\/\\1>', 'g'), function (match,from,content) {
+      const to = map[from];
+      return to + content + to;
+    })
+    // Other kind of strikethrough
+    .replace(/\s+~~(.*?)~~\s+/g, ' -$1- ')
+    // Named/Un-Named Code Block
+    .replace(/`{3,}(\w+)?((?:\n|[^`])+)`{3,}/g, function(match, synt, content) {
+      const code = '{code';
+      if (synt) code += ':' + synt;
+      return code + '}' + content + '{code}';
+    })
+    // Inline-Preformatted Text
+    .replace(/`([^`]+)`/g, '{{$1}}')
+    // Named Link
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '[$1|$2]')
+    // Un-Named Link
+    .replace(/<([^>]+)>/g, '[$1]')
+    // Single Paragraph Blockquote
+    .replace(/^>/gm, 'bq.')
+    // tables
+    .replace(/^\n((?:\|.*?)+\|)[ \t]*\n((?:\|\s*?\-{3,}\s*?)+\|)[ \t]*\n((?:(?:\|.*?)+\|[ \t]*\n)*)$/gm,
+      function (match, headerLine, separatorLine, rowstr) {
+        const headers = headerLine.match(/[^|]+(?=\|)/g);
+        const separators = separatorLine.match(/[^|]+(?=\|)/g);
+        if (headers.length !== separators.length) {
+          return match;
+        }
+        const rows = rowstr.split('\n');
+        if (rows.length === 1 + 1 && headers.length === 1) {
+          // panel
+          return '{panel:title=' + headers[0].trim() + '}\n' +
+            rowstr.replace(/^\|(.*)[ \t]*\|/, '$1').trim() +
+            '\n{panel}\n';
+        } else {
+          return '||' + headers.join('||') + '||\n' + rowstr;
+        }
+      });
 
 };
 

--- a/index.js
+++ b/index.js
@@ -29,9 +29,9 @@ J2M.prototype.to_markdown = function (str) {
       return Array(parseInt(level) + 1).join('#') + content;
     })
     // Bold
-    .replace(/(\s|^|\_)\*(\S.*?)\*($|[^a-zA-Z])/g, '$1**$2**$3')
+    .replace(/(\s|^|\_)\*(\S.*?)\*($|[~`!@#$%^&*(){}\[\];:"'<,.>?\/\\|_+=-]|\s)/g, '$1**$2**$3')
     // Italic
-    .replace(/(\s|^|\*)\_(\S.*?)\_($|[^a-zA-Z])/g, '$1*$2*$3')
+    .replace(/(\s|^|\*)\_(\S.*?)\_($|[~`!@#$%^&*(){}\[\];:"'<,.>?\/\\|_+=-]|\s)/g, '$1*$2*$3')
     // Monospaced text
     .replace(/\{\{([^}]+)\}\}/g, '`$1`')
     // Citations (buggy)
@@ -79,12 +79,12 @@ J2M.prototype.to_jira = function (str) {
 
   return str
     // Bold, Italic, and Combined (bold+italic)
-    .replace(/(\s|^)([*_]+)(\S.*?)\2/g, function (_match, whitespace, wrapper, content) {
+    .replace(/(\s?|^)([*_]+)(\S.*?)\2(\s|[~`!@#$%^&()\{\}\[\];:"'<,\.>?\/\\|+=-]|$)/gm, function (_match, opening_chars, wrapper, content, closing_chars) {
       switch (wrapper.length) {
-        case 1: return whitespace + '_' + content + '_';
-        case 2: return whitespace + "*" + content + "*";
-        case 3: return whitespace + "_*" + content + "*_";
-        default: return whitespace + wrapper + content * wrapper;
+        case 1: return opening_chars + '_' + content + '_' + closing_chars;
+        case 2: return opening_chars + "*" + content + "*" + closing_chars;
+        case 3: return opening_chars + "_*" + content + "*_" + closing_chars;
+        default: return opening_chars + wrapper + content * wrapper + closing_chars;
       }
     })
     // All Headers (# format)

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ J2M.prototype.to_markdown = function (str) {
       return Array(parseInt(level) + 1).join('#') + content;
     })
     // Bold
-    .replace(/\*(\S.*)\*/g, '**$1**')
+    .replace(/(\s|^|\_)\*(\S.*)\*/g, '$1**$2**')
     // Italic
     .replace(/(\s|^|\*)\_(\S.*)\_/g, '$1*$2*')
     // Monospaced text

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ J2M.prototype.to_markdown = function (str) {
     // Strikethrough
     .replace(/(\s|^)+-(\S+.*?\S)-+/g, '$1~~$2~~')
     // Code Block
-    .replace(/\{code(:([a-z]+))?([:|]?(title|borderStyle|borderColor|borderWidth|bgColor|titleBGColor)=.+?)*\}([^]*)\{code\}/gm, '```$2$5```')
+    .replace(/\{code(:([a-z]+))?([:|]?(title|borderStyle|borderColor|borderWidth|bgColor|titleBGColor)=.+?)*\}([^]*?)\{code\}/gm, '```$2$5```')
     // Pre-formatted text
     .replace(/{noformat}/g, '```')
     // Un-named Links

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
-var marked = require('marked');
+const marked = require('marked');
 marked.setOptions({
 	breaks: true,
 	smartyPants: true
 });
 
-var J2M = function() {};
+const J2M = function() {};
 
 J2M.prototype.md_to_html = function(str) {
 	return marked(str);
@@ -60,7 +60,7 @@ J2M.prototype.to_markdown = function(str) {
         .replace(/\{panel:title=([^}]*)\}\n?([^]*?)\n?\{panel\}/gm, '\n| $1 |\n| --- |\n| $2 |')
         // table header
         .replace(/^[ \t]*((?:\|\|.*?)+\|\|)[ \t]*$/gm, function (match, headers) {
-            var singleBarred =  headers.replace(/\|\|/g,'|');
+            const singleBarred =  headers.replace(/\|\|/g,'|');
             return '\n' + singleBarred + '\n' + singleBarred.replace(/\|[^|]+/g, '| --- ');
         })
         // remove leading-space of table headers and rows
@@ -69,7 +69,7 @@ J2M.prototype.to_markdown = function(str) {
 };
 
 J2M.prototype.to_jira = function(str) {
-    var map = {
+    const map = {
       //cite: '??',
       del: '-',
       ins: '+',
@@ -106,14 +106,14 @@ J2M.prototype.to_jira = function(str) {
         // Headers (h1 or h2) (lines "underlined" by ---- or =====)
         // Citations, Inserts, Subscripts, Superscripts, and Strikethroughs
         .replace(new RegExp('<(' + Object.keys(map).join('|') + ')>(.*?)<\/\\1>', 'g'), function (match,from,content) {
-            var to = map[from];
+            const to = map[from];
             return to + content + to;
         })
         // Other kind of strikethrough
         .replace(/\s+~~(.*?)~~\s+/g, ' -$1- ')
         // Named/Un-Named Code Block
         .replace(/`{3,}(\w+)?((?:\n|[^`])+)`{3,}/g, function(match, synt, content) {
-            var code = '{code';
+            const code = '{code';
             if (synt) code += ':' + synt;
             return code + '}' + content + '{code}';
         })
@@ -128,12 +128,12 @@ J2M.prototype.to_jira = function(str) {
         // tables
         .replace(/^\n((?:\|.*?)+\|)[ \t]*\n((?:\|\s*?\-{3,}\s*?)+\|)[ \t]*\n((?:(?:\|.*?)+\|[ \t]*\n)*)$/gm,
                  function (match, headerLine, separatorLine, rowstr) {
-                     var headers = headerLine.match(/[^|]+(?=\|)/g);
-                     var separators = separatorLine.match(/[^|]+(?=\|)/g);
+                     const headers = headerLine.match(/[^|]+(?=\|)/g);
+                     const separators = separatorLine.match(/[^|]+(?=\|)/g);
                      if (headers.length !== separators.length) {
                          return match;
                      }
-                     var rows = rowstr.split('\n');
+                     const rows = rowstr.split('\n');
                      if (rows.length === 1 + 1 && headers.length === 1) {
                          // panel
                          return '{panel:title=' + headers[0].trim() + '}\n' +

--- a/index.js
+++ b/index.js
@@ -112,8 +112,8 @@ J2M.prototype.to_jira = function (str) {
     // Other kind of strikethrough
     .replace(/\s+~~(.*?)~~\s+/g, ' -$1- ')
     // Named/Un-Named Code Block
-    .replace(/`{3,}(\w+)?((?:\n|[^`])+)`{3,}/g, function(match, synt, content) {
-      const code = '{code';
+    .replace(/`{3,}(\w+)?((?:\n|[^`])+)`{3,}/g, function (match, synt, content) {
+      let code = '{code';
       if (synt) code += ':' + synt;
       return code + '}' + content + '{code}';
     })

--- a/index.js
+++ b/index.js
@@ -17,15 +17,15 @@ J2M.prototype.jira_to_html = function (str) {
 J2M.prototype.to_markdown = function (str) {
   return str
     // Ordered Lists
-    .replace(/^[ \t]*(\*+)\s+/gm, function (match, stars) {
+    .replace(/^[ \t]*(\*+)\s+/gm, function (_match, stars) {
       return Array(stars.length).join("  ") + '* ';
     })
     // Un-ordered lists
-    .replace(/^[ \t]*(#+)\s+/gm, function (match, nums) {
+    .replace(/^[ \t]*(#+)\s+/gm, function (_match, nums) {
       return Array(nums.length).join("  ") + '1. ';
     })
     // Headers 1-6
-    .replace(/^h([0-6])\.(.*)$/gm, function (match, level, content) {
+    .replace(/^h([0-6])\.(.*)$/gm, function (_match, level, content) {
       return Array(parseInt(level) + 1).join('#') + content;
     })
     // Bold
@@ -59,7 +59,7 @@ J2M.prototype.to_markdown = function (str) {
     // panel into table
     .replace(/\{panel:title=([^}]*)\}\n?([^]*?)\n?\{panel\}/gm, '\n| $1 |\n| --- |\n| $2 |')
     // table header
-    .replace(/^[ \t]*((?:\|\|.*?)+\|\|)[ \t]*$/gm, function (match, headers) {
+    .replace(/^[ \t]*((?:\|\|.*?)+\|\|)[ \t]*$/gm, function (_match, headers) {
       const singleBarred = headers.replace(/\|\|/g, '|');
       return '\n' + singleBarred + '\n' + singleBarred.replace(/\|[^|]+/g, '| --- ');
     })
@@ -88,31 +88,31 @@ J2M.prototype.to_jira = function (str) {
       }
     })
     // All Headers (# format)
-    .replace(/^([#]+)(.*?)$/gm, function (match, level, content) {
+    .replace(/^([#]+)(.*?)$/gm, function (_match, level, content) {
       return 'h' + level.length + '.' + content;
     })
     // Headers (H1 and H2 underlines)
-    .replace(/^(.*?)\n([=-]+)$/gm, function (match, content, level) {
+    .replace(/^(.*?)\n([=-]+)$/gm, function (_match, content, level) {
       return 'h' + (level[0] === '=' ? 1 : 2) + '. ' + content;
     })
     // Ordered lists
-    .replace(/^([ \t]*)\d+\.\s+/gm, function (match, spaces) {
+    .replace(/^([ \t]*)\d+\.\s+/gm, function (_match, spaces) {
       return Array(Math.floor(spaces.length / 2 + 1)).join("#") + '# ';
     })
     // Un-Ordered Lists
-    .replace(/^([ \t]*)\*\s+/gm, function (match, spaces) {
+    .replace(/^([ \t]*)\*\s+/gm, function (_match, spaces) {
       return Array(Math.floor(spaces.length / 2 + 1)).join("*") + '* ';
     })
     // Headers (h1 or h2) (lines "underlined" by ---- or =====)
     // Citations, Inserts, Subscripts, Superscripts, and Strikethroughs
-    .replace(new RegExp('<(' + Object.keys(map).join('|') + ')>(.*?)<\/\\1>', 'g'), function (match, from, content) {
+    .replace(new RegExp('<(' + Object.keys(map).join('|') + ')>(.*?)<\/\\1>', 'g'), function (_match, from, content) {
       const to = map[from];
       return to + content + to;
     })
     // Other kind of strikethrough
     .replace(/(\s|^)+\~~(.*?)\~~+/g, '$1-$2-')
     // Named/Un-Named Code Block
-    .replace(/`{3,}(\w+)?((?:\n|[^`])+)`{3,}/g, function (match, synt, content) {
+    .replace(/`{3,}(\w+)?((?:\n|[^`])+)`{3,}/g, function (_match, synt, content) {
       let code = '{code';
       if (synt) code += ':' + synt;
       return code + '}' + content + '{code}';

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ J2M.prototype.to_markdown = function (str) {
     // Bold
     .replace(/\*(\S.*)\*/g, '**$1**')
     // Italic
-    .replace(/\_(\S.*)\_/g, '*$1*')
+    .replace(/(\s|^|\*)\_(\S.*)\_/g, '$1*$2*')
     // Monospaced text
     .replace(/\{\{([^}]+)\}\}/g, '`$1`')
     // Citations (buggy)

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ J2M.prototype.to_markdown = function(str) {
         // Subscript
         .replace(/~([^~]*)~/g, '<sub>$1</sub>')
         // Strikethrough
-        .replace(/\s+-(\S+.*?\S)-\s+/g, ' ~~$1~~ ')
+        .replace(/(\s|^)+-(\S+.*?\S)-+/g, '$1~~$2~~')
         // Code Block
         .replace(/\{code(:([a-z]+))?([:|]?(title|borderStyle|borderColor|borderWidth|bgColor|titleBGColor)=.+?)*\}([^]*)\{code\}/gm, '```$2$5```')
         // Pre-formatted text

--- a/index.js
+++ b/index.js
@@ -4,24 +4,28 @@ marked.setOptions({
   smartyPants: true
 });
 
-const J2M = function () { };
+class J2M {
+  constructor(str) {
+    this.str = str;
+  }
 
-J2M.prototype.md_to_html = function (str) {
-  return marked(str);
-};
+  md_to_html(str) {
+    return marked(str);
+  };
 
-J2M.prototype.jira_to_html = function (str) {
-  return marked(this.to_markdown(str));
-};
+  jira_to_html(str) {
+    return marked(this.to_markdown(str));
+  };
 
-J2M.prototype.to_jira = function (str) {
-  let hash = splitOutCodeblocks(str, 'toJira');
-  return transformHash(hash, 'toJira')
-};
+  to_jira(str) {
+    let hash = splitOutCodeblocks(str, 'toJira');
+    return transformHash(hash, 'toJira')
+  };
 
-J2M.prototype.to_markdown = function (str) {
-  let hash = splitOutCodeblocks(str, 'toMarkdown');
-  return transformHash(hash, 'toMarkdown')
+  to_markdown(str) {
+    let hash = splitOutCodeblocks(str, 'toMarkdown');
+    return transformHash(hash, 'toMarkdown')
+  };
 };
 
 const transformHash = function (hash, direction) {

--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ J2M.prototype.to_jira = function (str) {
       return to + content + to;
     })
     // Other kind of strikethrough
-    .replace(/\s+~~(.*?)~~\s+/g, ' -$1- ')
+    .replace(/(\s|^)+\~~(.*?)\~~+/g, '$1-$2-')
     // Named/Un-Named Code Block
     .replace(/`{3,}(\w+)?((?:\n|[^`])+)`{3,}/g, function (match, synt, content) {
       let code = '{code';

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ const transformHash = function (hash, direction) {
         string += toMarkdownFormatting(hash[key]['string']);
       };
     });
-  } else {
+  } else if (direction == 'toJira'){
     Object.keys(hash).forEach((key) => {
       if (hash[key]['code']) {
         string += codeblockToJira(hash[key]['string']);
@@ -47,6 +47,8 @@ const transformHash = function (hash, direction) {
         string += toJiraFormatting(hash[key]['string']);
       };
     });
+  } else {
+    throw 'Direction is invalid.'
   }
   return string
 };

--- a/index.js
+++ b/index.js
@@ -29,9 +29,9 @@ J2M.prototype.to_markdown = function (str) {
       return Array(parseInt(level) + 1).join('#') + content;
     })
     // Bold
-    .replace(/(\s|^|\_)\*(\S.*)\*/g, '$1**$2**')
+    .replace(/(\s|^|\_)\*(\S.*?)\*/g, '$1**$2**')
     // Italic
-    .replace(/(\s|^|\*)\_(\S.*)\_/g, '$1*$2*')
+    .replace(/(\s|^|\*)\_(\S.*?)\_/g, '$1*$2*')
     // Monospaced text
     .replace(/\{\{([^}]+)\}\}/g, '`$1`')
     // Citations (buggy)

--- a/index.js
+++ b/index.js
@@ -49,10 +49,9 @@ const transformHash = function (hash, direction) {
 
 const splitOutCodeblocks = function (str, direction) {
   let hash = {};
-  // hash = {0: {string: 'not code', iscodeblock: false}, 1: {string: ```code```, iscodeblock: true}}
   let array = [];
 
-  // This block should return an array where each element is either a codeblock or is not
+  // This block returns an array where each element is either a codeblock or is not
   if (direction == 'toMarkdown') {
     array = str.split(/(\{code[^]*?\{code\}|\{noformat[^]*?\{noformat\})/)
   } else if (direction == 'toJira') {

--- a/index.js
+++ b/index.js
@@ -1,27 +1,27 @@
 const marked = require('marked');
 marked.setOptions({
-	breaks: true,
-	smartyPants: true
+  breaks: true,
+  smartyPants: true
 });
 
-const J2M = function() {};
+const J2M = function () { };
 
-J2M.prototype.md_to_html = function(str) {
-	return marked(str);
+J2M.prototype.md_to_html = function (str) {
+  return marked(str);
 };
 
-J2M.prototype.jira_to_html = function(str) {
-	return marked(this.to_markdown(str));
+J2M.prototype.jira_to_html = function (str) {
+  return marked(this.to_markdown(str));
 };
 
-J2M.prototype.to_markdown = function(str) {
+J2M.prototype.to_markdown = function (str) {
   return str
     // Ordered Lists
-    .replace(/^[ \t]*(\*+)\s+/gm, function(match, stars) {
+    .replace(/^[ \t]*(\*+)\s+/gm, function (match, stars) {
       return Array(stars.length).join("  ") + '* ';
     })
     // Un-ordered lists
-    .replace(/^[ \t]*(#+)\s+/gm, function(match, nums) {
+    .replace(/^[ \t]*(#+)\s+/gm, function (match, nums) {
       return Array(nums.length).join("  ") + '1. ';
     })
     // Headers 1-6
@@ -60,7 +60,7 @@ J2M.prototype.to_markdown = function(str) {
     .replace(/\{panel:title=([^}]*)\}\n?([^]*?)\n?\{panel\}/gm, '\n| $1 |\n| --- |\n| $2 |')
     // table header
     .replace(/^[ \t]*((?:\|\|.*?)+\|\|)[ \t]*$/gm, function (match, headers) {
-      const singleBarred =  headers.replace(/\|\|/g,'|');
+      const singleBarred = headers.replace(/\|\|/g, '|');
       return '\n' + singleBarred + '\n' + singleBarred.replace(/\|[^|]+/g, '| --- ');
     })
     // remove leading-space of table headers and rows
@@ -68,7 +68,7 @@ J2M.prototype.to_markdown = function(str) {
 
 };
 
-J2M.prototype.to_jira = function(str) {
+J2M.prototype.to_jira = function (str) {
   const map = {
     //cite: '??',
     del: '-',
@@ -79,7 +79,7 @@ J2M.prototype.to_jira = function(str) {
 
   return str
     // Bold, Italic, and Combined (bold+italic)
-    .replace(/([*_]+)(\S.*?)\1/g, function (match,wrapper,content) {
+    .replace(/([*_]+)(\S.*?)\1/g, function (match, wrapper, content) {
       switch (wrapper.length) {
         case 1: return '_' + content + '_';
         case 2: return '*' + content + '*';
@@ -88,24 +88,24 @@ J2M.prototype.to_jira = function(str) {
       }
     })
     // All Headers (# format)
-    .replace(/^([#]+)(.*?)$/gm, function (match,level,content) {
+    .replace(/^([#]+)(.*?)$/gm, function (match, level, content) {
       return 'h' + level.length + '.' + content;
     })
     // Headers (H1 and H2 underlines)
-    .replace(/^(.*?)\n([=-]+)$/gm, function (match,content,level) {
+    .replace(/^(.*?)\n([=-]+)$/gm, function (match, content, level) {
       return 'h' + (level[0] === '=' ? 1 : 2) + '. ' + content;
     })
     // Ordered lists
-    .replace(/^([ \t]*)\d+\.\s+/gm, function(match, spaces) {
-      return Array(Math.floor(spaces.length/2 + 1)).join("#") + '# ';
+    .replace(/^([ \t]*)\d+\.\s+/gm, function (match, spaces) {
+      return Array(Math.floor(spaces.length / 2 + 1)).join("#") + '# ';
     })
     // Un-Ordered Lists
-    .replace(/^([ \t]*)\*\s+/gm, function(match, spaces) {
-      return Array(Math.floor(spaces.length/2 + 1)).join("*") + '* ';
+    .replace(/^([ \t]*)\*\s+/gm, function (match, spaces) {
+      return Array(Math.floor(spaces.length / 2 + 1)).join("*") + '* ';
     })
     // Headers (h1 or h2) (lines "underlined" by ---- or =====)
     // Citations, Inserts, Subscripts, Superscripts, and Strikethroughs
-    .replace(new RegExp('<(' + Object.keys(map).join('|') + ')>(.*?)<\/\\1>', 'g'), function (match,from,content) {
+    .replace(new RegExp('<(' + Object.keys(map).join('|') + ')>(.*?)<\/\\1>', 'g'), function (match, from, content) {
       const to = map[from];
       return to + content + to;
     })

--- a/index.js
+++ b/index.js
@@ -79,12 +79,12 @@ J2M.prototype.to_jira = function (str) {
 
   return str
     // Bold, Italic, and Combined (bold+italic)
-    .replace(/([*_]+)(\S.*?)\1/g, function (match, wrapper, content) {
+    .replace(/(\s|^)([*_]+)(\S.*?)\2/g, function (_match, whitespace, wrapper, content) {
       switch (wrapper.length) {
-        case 1: return '_' + content + '_';
-        case 2: return '*' + content + '*';
-        case 3: return '_*' + content + '*_';
-        default: return wrapper + content * wrapper;
+        case 1: return whitespace + '_' + content + '_';
+        case 2: return whitespace + "*" + content + "*";
+        case 3: return whitespace + "_*" + content + "*_";
+        default: return whitespace + wrapper + content * wrapper;
       }
     })
     // All Headers (# format)

--- a/index.js
+++ b/index.js
@@ -29,9 +29,9 @@ J2M.prototype.to_markdown = function (str) {
       return Array(parseInt(level) + 1).join('#') + content;
     })
     // Bold
-    .replace(/(\s|^|\_)\*(\S.*?)\*/g, '$1**$2**')
+    .replace(/(\s|^|\_)\*(\S.*?)\*($|[^a-zA-Z])/g, '$1**$2**$3')
     // Italic
-    .replace(/(\s|^|\*)\_(\S.*?)\_/g, '$1*$2*')
+    .replace(/(\s|^|\*)\_(\S.*?)\_($|[^a-zA-Z])/g, '$1*$2*$3')
     // Monospaced text
     .replace(/\{\{([^}]+)\}\}/g, '`$1`')
     // Citations (buggy)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,217 @@
+{
+  "name": "jira2md",
+  "version": "2.0.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+    },
+    "chai": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.1.0",
+        "deep-eql": "0.1.3",
+        "type-detect": "1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "dev": true,
+      "requires": {
+        "type-detect": "0.1.1"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+          "dev": true
+        }
+      }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "marked": {
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "requires": {
+        "has-flag": "3.0.0"
+      }
+    },
+    "type-detect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "chai": "^3.5.0"
   },
   "scripts": {
-    "test": "make test"
+    "test": "mocha --timeout 5000 --check-leaks --reporter spec test/*.js"
   },
   "author": "Fokke Zandbergen <mail@fokkezb.nl>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "description": "JIRA to MarkDown text format converter.",
   "main": "index.js",
   "devDependencies": {
-    "chai": "^3.3.0"
+    "chai": "^3.5.0"
   },
   "scripts": {
     "test": "make test"
@@ -27,6 +27,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "marked": "^0.3.5"
+    "marked": "^0.3.5",
+    "mocha": "^5.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,15 +7,16 @@
     "wiki",
     "markdown"
   ],
-  "homepage": "http://github.com/kylefarris/J2M.git",
+  "homepage": "http://github.com/karimatthews/J2M.git",
   "repository": {
     "type": "git",
-    "url": "http://github.com/kylefarris/J2M.git"
+    "url": "http://github.com/karimatthews/J2M.git"
   },
   "description": "JIRA to MarkDown text format converter.",
   "main": "index.js",
   "devDependencies": {
-    "chai": "^3.5.0"
+    "chai": "^3.5.0",
+    "mocha": "^5.2.0"
   },
   "scripts": {
     "test": "mocha --timeout 5000 --check-leaks --reporter spec test/*.js"
@@ -23,11 +24,11 @@
   "author": "Fokke Zandbergen <mail@fokkezb.nl>",
   "contributors": [
     "Kyle Farris <kyle@chomponllc.com>",
-    "Eryk Warren <https://github.com/erykwarren>"
+    "Eryk Warren <https://github.com/erykwarren>",
+    "Kari Matthews <https://github.com/karimatthews>"
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "marked": "^0.3.5",
-    "mocha": "^5.2.0"
+    "marked": "^0.3.5"
   }
 }

--- a/test/jira2md.js
+++ b/test/jira2md.js
@@ -1,128 +1,151 @@
 var should = require('chai').should();
-var expect = require('chai').expect;
+// var expect = require('chai').expect;
 var fs = require('fs');
 var path = require('path');
 var j2m = require('../index.js');
 
-describe('to_markdown', function() {
-    it('should exist', function() {
-    	should.exist(j2m.to_markdown);
-    });
-    it('should be a function', function() {
-    	j2m.to_markdown.should.be.a('function');
-    });
-    it('should convert bolds properly', function() {
-        var markdown = j2m.to_markdown('*bold*');
-        markdown.should.eql('**bold**');
-    });
-    it('should convert italics properly', function() {
-        var markdown = j2m.to_markdown('_italic_');
-        markdown.should.eql('*italic*');
-    });
-    it('should convert monospaced content properly', function() {
-        var markdown = j2m.to_markdown('{{monospaced}}');
-        markdown.should.eql('`monospaced`');
-    });
-    //it('should convert citations properly', function() {
-    //    var markdown = j2m.to_markdown('??citation??');
-    //    markdown.should.eql('<cite>citation</cite>');
-    //});
-    it('should convert strikethroughs properly', function() {
-        var markdown = j2m.to_markdown('-deleted-');
-        markdown.should.eql('~~deleted~~');
-    });
-    it('should convert inserts properly', function() {
-        var markdown = j2m.to_markdown('+inserted+');
-        markdown.should.eql('<ins>inserted</ins>');
-    });
-    it('should convert superscript properly', function() {
-        var markdown = j2m.to_markdown('^superscript^');
-        markdown.should.eql('<sup>superscript</sup>');
-    });
-    it('should convert subscript properly', function() {
-        var markdown = j2m.to_markdown('~subscript~');
-        markdown.should.eql('<sub>subscript</sub>');
-    });
-    it('should convert preformatted blocks properly', function() {
-        var markdown = j2m.to_markdown("{noformat}\nso *no* further _formatting_ is done here\n{noformat}");
-        markdown.should.eql("```\nso **no** further *formatting* is done here\n```");
-    });
-    it('should convert language-specific code blocks properly', function() {
-        var markdown = j2m.to_markdown("{code:javascript}\nvar hello = 'world';\n{code}");
-        markdown.should.eql("```javascript\nvar hello = 'world';\n```");
-    });
-    it('should convert code without language-specific and with title into code block', function() {
-        var markdown = j2m.to_markdown("{code:title=Foo.java}\nclass Foo {\n  public static void main() {\n  }\n}\n{code}");
-        markdown.should.eql("```\nclass Foo {\n  public static void main() {\n  }\n}\n```")
-    });
-    it('should convert fully configured code block', function() {
-        var markdown = j2m.to_markdown(
-            "{code:xml|title=My Title|borderStyle=dashed|borderColor=#ccc|titleBGColor=#F7D6C1|bgColor=#FFFFCE}"
-            + "\n    <test>"
-            + "\n        <another tag=\"attribute\"/>"
-            + "\n    </test>"
-            + "\n{code}");
-        markdown.should.eql(
-            "```xml"
-            + "\n    <test>"
-            + "\n        <another tag=\"attribute\"/>"
-            + "\n    </test>"
-            + "\n```");
-    });
-    it('should convert unnamed links properly', function() {
-        var markdown = j2m.to_markdown("[http://google.com]");
-        markdown.should.eql("<http://google.com>");
-    });
-    it('should convert named links properly', function() {
-        var markdown = j2m.to_markdown("[Google|http://google.com]");
-        markdown.should.eql("[Google](http://google.com)");
-    });
-    it('should convert headers properly', function() {
-        var h1 = j2m.to_markdown("h1. Biggest heading");
-        var h2 = j2m.to_markdown("h2. Bigger heading");
-        var h3 = j2m.to_markdown("h3. Big heading");
-        var h4 = j2m.to_markdown("h4. Normal heading");
-        var h5 = j2m.to_markdown("h5. Small heading");
-        var h6 = j2m.to_markdown("h6. Smallest heading");
-        h1.should.eql("# Biggest heading");
-        h2.should.eql("## Bigger heading");
-        h3.should.eql("### Big heading");
-        h4.should.eql("#### Normal heading");
-        h5.should.eql("##### Small heading");
-        h6.should.eql("###### Smallest heading");
-    });
-    it('should convert blockquotes properly', function() {
-        var markdown = j2m.to_markdown("bq. This is a long blockquote type thingy that needs to be converted.");
-        markdown.should.eql("> This is a long blockquote type thingy that needs to be converted.");
-    });
-    it('should convert un-ordered lists properly', function() {
-        var markdown = j2m.to_markdown("* Foo\n* Bar\n* Baz\n** FooBar\n** BarBaz\n*** FooBarBaz\n* Starting Over");
-        markdown.should.eql("* Foo\n* Bar\n* Baz\n  * FooBar\n  * BarBaz\n    * FooBarBaz\n* Starting Over");
-    });
-    it('should convert ordered lists properly', function() {
-        var markdown = j2m.to_markdown("# Foo\n# Bar\n# Baz\n## FooBar\n## BarBaz\n### FooBarBaz\n# Starting Over");
-        markdown.should.eql("1. Foo\n1. Bar\n1. Baz\n  1. FooBar\n  1. BarBaz\n    1. FooBarBaz\n1. Starting Over");
-    });
-    it('should handle bold AND italic (combined) correctly', function() {
-        var markdown = j2m.to_markdown("This is _*emphatically bold*_!");
-        markdown.should.eql("This is ***emphatically bold***!");
-    });
-    it('should handle bold within a un-ordered list item', function() {
-        var markdown = j2m.to_markdown("* This is not bold!\n** This is *bold*.");
-        markdown.should.eql("* This is not bold!\n  * This is **bold**.");
-    });
-    it.skip('should be able to handle a complicated multi-line jira-wiki string and convert it to markdown', function() {
-        var jira_str = fs.readFileSync(path.resolve(__dirname, 'test.jira'),"utf8");
-        var md_str = fs.readFileSync(path.resolve(__dirname, 'test.md'),"utf8");
-        var markdown = j2m.to_markdown(jira_str);
-        markdown.should.eql(md_str);
-    });
-    it('should not recognize strikethroughs over multiple lines', function() {
-        var markdown = j2m.to_markdown("* Here's an un-ordered list line\n* Multi-line strikethroughs shouldn't work.");
-        markdown.should.eql("* Here's an un-ordered list line\n* Multi-line strikethroughs shouldn't work.");
-    });
-    it('should remove color attributes', function() {
-        var markdown = j2m.to_markdown("A text with{color:blue} blue \n lines {color} is not necessary.");
-        markdown.should.eql("A text with blue \n lines  is not necessary.");
-    });
+describe('to_markdown', function () {
+  it('should exist', function () {
+    should.exist(j2m.to_markdown);
+  });
+
+  it('should be a function', function () {
+    j2m.to_markdown.should.be.a('function');
+  });
+
+  it('should convert bolds properly', function () {
+    var markdown = j2m.to_markdown('*bold*');
+    markdown.should.eql('**bold**');
+  });
+
+  it('should convert italics properly', function () {
+    var markdown = j2m.to_markdown('_italic_');
+    markdown.should.eql('*italic*');
+  });
+
+  it('should convert monospaced content properly', function () {
+    var markdown = j2m.to_markdown('{{monospaced}}');
+    markdown.should.eql('`monospaced`');
+  });
+
+  //it('should convert citations properly', function() {
+  //    var markdown = j2m.to_markdown('??citation??');
+  //    markdown.should.eql('<cite>citation</cite>');
+  //});
+  it('should convert strikethroughs properly', function () {
+    var markdown = j2m.to_markdown('-deleted-');
+    markdown.should.eql('~~deleted~~');
+  });
+
+  it('should convert inserts properly', function () {
+    var markdown = j2m.to_markdown('+inserted+');
+    markdown.should.eql('<ins>inserted</ins>');
+  });
+
+  it('should convert superscript properly', function () {
+    var markdown = j2m.to_markdown('^superscript^');
+    markdown.should.eql('<sup>superscript</sup>');
+  });
+
+  it('should convert subscript properly', function () {
+    var markdown = j2m.to_markdown('~subscript~');
+    markdown.should.eql('<sub>subscript</sub>');
+  });
+
+  it('should convert preformatted blocks properly', function () {
+    var markdown = j2m.to_markdown("{noformat}\nso *no* further _formatting_ is done here\n{noformat}");
+    markdown.should.eql("```\nso **no** further *formatting* is done here\n```");
+  });
+
+  it('should convert language-specific code blocks properly', function () {
+    var markdown = j2m.to_markdown("{code:javascript}\nvar hello = 'world';\n{code}");
+    markdown.should.eql("```javascript\nvar hello = 'world';\n```");
+  });
+
+  it('should convert code without language-specific and with title into code block', function () {
+    var markdown = j2m.to_markdown("{code:title=Foo.java}\nclass Foo {\n  public static void main() {\n  }\n}\n{code}");
+    markdown.should.eql("```\nclass Foo {\n  public static void main() {\n  }\n}\n```")
+  });
+
+  it('should convert fully configured code block', function () {
+    var markdown = j2m.to_markdown(
+      "{code:xml|title=My Title|borderStyle=dashed|borderColor=#ccc|titleBGColor=#F7D6C1|bgColor=#FFFFCE}"
+      + "\n    <test>"
+      + "\n        <another tag=\"attribute\"/>"
+      + "\n    </test>"
+      + "\n{code}");
+    markdown.should.eql(
+      "```xml"
+      + "\n    <test>"
+      + "\n        <another tag=\"attribute\"/>"
+      + "\n    </test>"
+      + "\n```");
+  });
+
+  it('should convert unnamed links properly', function () {
+    var markdown = j2m.to_markdown("[http://google.com]");
+    markdown.should.eql("<http://google.com>");
+  });
+
+  it('should convert named links properly', function () {
+    var markdown = j2m.to_markdown("[Google|http://google.com]");
+    markdown.should.eql("[Google](http://google.com)");
+  });
+
+  it('should convert headers properly', function () {
+    var h1 = j2m.to_markdown("h1. Biggest heading");
+    var h2 = j2m.to_markdown("h2. Bigger heading");
+    var h3 = j2m.to_markdown("h3. Big heading");
+    var h4 = j2m.to_markdown("h4. Normal heading");
+    var h5 = j2m.to_markdown("h5. Small heading");
+    var h6 = j2m.to_markdown("h6. Smallest heading");
+    h1.should.eql("# Biggest heading");
+    h2.should.eql("## Bigger heading");
+    h3.should.eql("### Big heading");
+    h4.should.eql("#### Normal heading");
+    h5.should.eql("##### Small heading");
+    h6.should.eql("###### Smallest heading");
+  });
+
+  it('should convert blockquotes properly', function () {
+    var markdown = j2m.to_markdown("bq. This is a long blockquote type thingy that needs to be converted.");
+    markdown.should.eql("> This is a long blockquote type thingy that needs to be converted.");
+  });
+
+  it('should convert un-ordered lists properly', function () {
+    var markdown = j2m.to_markdown("* Foo\n* Bar\n* Baz\n** FooBar\n** BarBaz\n*** FooBarBaz\n* Starting Over");
+    markdown.should.eql("* Foo\n* Bar\n* Baz\n  * FooBar\n  * BarBaz\n    * FooBarBaz\n* Starting Over");
+  });
+
+  it('should convert ordered lists properly', function () {
+    var markdown = j2m.to_markdown("# Foo\n# Bar\n# Baz\n## FooBar\n## BarBaz\n### FooBarBaz\n# Starting Over");
+    markdown.should.eql("1. Foo\n1. Bar\n1. Baz\n  1. FooBar\n  1. BarBaz\n    1. FooBarBaz\n1. Starting Over");
+  });
+
+  it('should handle bold AND italic (combined) correctly', function () {
+    var markdown = j2m.to_markdown("This is _*emphatically bold*_!");
+    markdown.should.eql("This is ***emphatically bold***!");
+  });
+
+  it('should handle bold within a un-ordered list item', function () {
+    var markdown = j2m.to_markdown("* This is not bold!\n** This is *bold*.");
+    markdown.should.eql("* This is not bold!\n  * This is **bold**.");
+  });
+
+  it.skip('should be able to handle a complicated multi-line jira-wiki string and convert it to markdown', function () {
+    var jira_str = fs.readFileSync(path.resolve(__dirname, 'test.jira'), "utf8");
+    var md_str = fs.readFileSync(path.resolve(__dirname, 'test.md'), "utf8");
+    var markdown = j2m.to_markdown(jira_str);
+    markdown.should.eql(md_str);
+  });
+
+  it('should not recognize strikethroughs over multiple lines', function () {
+    var markdown = j2m.to_markdown("* Here's an un-ordered list line\n* Multi-line strikethroughs shouldn't work.");
+    markdown.should.eql("* Here's an un-ordered list line\n* Multi-line strikethroughs shouldn't work.");
+  });
+
+  it('should remove color attributes', function () {
+    var markdown = j2m.to_markdown("A text with{color:blue} blue \n lines {color} is not necessary.");
+    markdown.should.eql("A text with blue \n lines  is not necessary.");
+  });
 });

--- a/test/jira2md.js
+++ b/test/jira2md.js
@@ -14,8 +14,13 @@ describe('to_markdown', function () {
   });
 
   it('should convert bolds properly', function () {
-    var markdown = j2m.to_markdown('*bold*');
-    markdown.should.eql('**bold**');
+    var markdown = j2m.to_markdown('*bold words*');
+    markdown.should.eql('**bold words**');
+  });
+
+  it('does not perform intraword formatting on underscores', function () {
+    var markdown = j2m.to_markdown('a_phrase_with_underscores');
+    markdown.should.eql('a_phrase_with_underscores');
   });
 
   it('should convert italics properly', function () {

--- a/test/jira2md.js
+++ b/test/jira2md.js
@@ -219,4 +219,9 @@ describe('to_markdown', function () {
     var markdown = j2m.to_markdown("A text with{color:blue} blue \n lines {color} is not necessary.");
     markdown.should.eql("A text with blue \n lines  is not necessary.");
   });
+
+  it('should leave urls unchanged', function () {
+    var markdown = j2m.to_markdown('https://example_url_thing.com');
+    markdown.should.eql('https://example_url_thing.com');
+  });
 });

--- a/test/jira2md.js
+++ b/test/jira2md.js
@@ -103,6 +103,11 @@ describe('to_markdown', function () {
       + "\n```");
   });
 
+  it('should convert multiple codeblocks properly', function () {
+    var markdown = j2m.to_markdown("{code:title=Foo.java}\nclass Foo {\n  public static void main() {\n  }\n}\n{code} \n {code:title=Foo.java}\nclass Foo {\n  public static void main() {\n  }\n}\n{code}");
+    markdown.should.eql("```\nclass Foo {\n  public static void main() {\n  }\n}\n``` \n ```\nclass Foo {\n  public static void main() {\n  }\n}\n```");
+  });
+
   it('should convert unnamed links properly', function () {
     var markdown = j2m.to_markdown("[http://google.com]");
     markdown.should.eql("<http://google.com>");

--- a/test/jira2md.js
+++ b/test/jira2md.js
@@ -13,64 +13,75 @@ describe('to_markdown', function () {
     j2m.to_markdown.should.be.a('function');
   });
 
-  it('should convert bolds properly', function () {
-    var markdown = j2m.to_markdown('*bold words*');
-    markdown.should.eql('**bold words**');
-  });
+  describe('emphasis formatting', function () {
+    describe('bold formatting', function () {
+      it('should convert bolds properly', function () {
+        var markdown = j2m.to_markdown('*bold words*');
+        markdown.should.eql('**bold words**');
+      });
 
-  it("should handle multiple bold sections in a line", function() {
-    var markdown = j2m.to_markdown("*this should be bold* this should not *this should be bold*");
-    markdown.should.eql("**this should be bold** this should not **this should be bold**");
-  });
+      it("should handle multiple bold sections in a line", function () {
+        var markdown = j2m.to_markdown("*this should be bold* this should not *this should be bold*");
+        markdown.should.eql("**this should be bold** this should not **this should be bold**");
+      });
 
-  it("does not perform intraword formatting on asterisks", function() {
-    var markdown = j2m.to_markdown("a*phrase*with*asterisks");
-    markdown.should.eql("a*phrase*with*asterisks");
-  });
+      it("does not perform intraword formatting on asterisks", function () {
+        var markdown = j2m.to_markdown("a*phrase*with*asterisks");
+        markdown.should.eql("a*phrase*with*asterisks");
+      });
 
-  it('does not apply bold formatting without an underscore at the end of the phrase', function () {
-    var markdown = j2m.to_markdown('*a*phrase');
-    markdown.should.eql('*a*phrase');
-  });
+      it('does not apply bold formatting without an underscore at the end of the phrase', function () {
+        var markdown = j2m.to_markdown('*a*phrase');
+        markdown.should.eql('*a*phrase');
+      });
 
-  it('formats bolds while leaving intraword asterisks untouched', function () {
-    var markdown = j2m.to_markdown('*bold*phrase*with*internal*asterisks*');
-    markdown.should.eql('**bold*phrase*with*internal*asterisks**');
-  });
+      it('formats bolds while leaving intraword asterisks untouched', function () {
+        var markdown = j2m.to_markdown('*bold*phrase*with*internal*asterisks*');
+        markdown.should.eql('**bold*phrase*with*internal*asterisks**');
+      });
 
-  it('handles bolds at the end of sentences', function () {
-    var markdown = j2m.to_markdown('A sentence ending in *bold*.');
-    markdown.should.eql('A sentence ending in **bold**.');
-  });
+      it('handles bolds at the end of sentences', function () {
+        var markdown = j2m.to_markdown('A sentence ending in *bold*.');
+        markdown.should.eql('A sentence ending in **bold**.');
+      });
+    });
 
-  it('should convert italics properly', function () {
-    var markdown = j2m.to_markdown('_italic_');
-    markdown.should.eql('*italic*');
-  });
+    describe('italic formatting', function () {
+      it('should convert italics properly', function () {
+        var markdown = j2m.to_markdown('_italic_');
+        markdown.should.eql('*italic*');
+      });
 
-  it("should handle multiple italic sections in a line", function () {
-    var markdown = j2m.to_markdown("_this should be italic_ this should not _this should be italic_");
-    markdown.should.eql("*this should be italic* this should not *this should be italic*");
-  });
+      it("should handle multiple italic sections in a line", function () {
+        var markdown = j2m.to_markdown("_this should be italic_ this should not _this should be italic_");
+        markdown.should.eql("*this should be italic* this should not *this should be italic*");
+      });
 
-  it('does not perform intraword formatting on underscores', function () {
-    var markdown = j2m.to_markdown('a_phrase_with_underscores');
-    markdown.should.eql('a_phrase_with_underscores');
-  });
+      it('does not perform intraword formatting on underscores', function () {
+        var markdown = j2m.to_markdown('a_phrase_with_underscores');
+        markdown.should.eql('a_phrase_with_underscores');
+      });
 
-  it('does not apply italic formatting without an underscore at the end of the phrase', function () {
-    var markdown = j2m.to_markdown('_a_phrase');
-    markdown.should.eql('_a_phrase');
-  });
+      it('does not apply italic formatting without an underscore at the end of the phrase', function () {
+        var markdown = j2m.to_markdown('_a_phrase');
+        markdown.should.eql('_a_phrase');
+      });
 
-  it('formats italics while leaving intraword underscores untouched', function () {
-    var markdown = j2m.to_markdown('_italic_phrase_with_internal_underscores_');
-    markdown.should.eql('*italic_phrase_with_internal_underscores*');
-  });
+      it('formats italics while leaving intraword underscores untouched', function () {
+        var markdown = j2m.to_markdown('_italic_phrase_with_internal_underscores_');
+        markdown.should.eql('*italic_phrase_with_internal_underscores*');
+      });
 
-  it('handles italics at the end of sentences', function () {
-    var markdown = j2m.to_markdown('A sentence ending in _italic_.');
-    markdown.should.eql('A sentence ending in *italic*.');
+      it('handles italics at the end of sentences', function () {
+        var markdown = j2m.to_markdown('A sentence ending in _italic_.');
+        markdown.should.eql('A sentence ending in *italic*.');
+      });
+    });
+
+    it('should handle bold AND italic (combined) correctly', function () {
+      var markdown = j2m.to_markdown("This is _*emphatically bold*_!");
+      markdown.should.eql("This is ***emphatically bold***!");
+    });
   });
 
   it('should convert monospaced content properly', function () {
@@ -108,39 +119,41 @@ describe('to_markdown', function () {
     markdown.should.eql("```\nso *no* further _formatting_ is done here\n```");
   });
 
-  it('should not apply formatting within codeblocks', function () {
-    var markdown = j2m.to_markdown("{code}\nso *no* further _formatting_ is done here\n{code}");
-    markdown.should.eql("```\nso *no* further _formatting_ is done here\n```");
-  });
+  describe('code block formatting', function () {
+    it('should not apply formatting within codeblocks', function () {
+      var markdown = j2m.to_markdown("{code}\nso *no* further _formatting_ is done here\n{code}");
+      markdown.should.eql("```\nso *no* further _formatting_ is done here\n```");
+    });
 
-  it('should convert language-specific code blocks properly', function () {
-    var markdown = j2m.to_markdown("{code:javascript}\nvar hello = 'world';\n{code}");
-    markdown.should.eql("```javascript\nvar hello = 'world';\n```");
-  });
+    it('should convert language-specific code blocks properly', function () {
+      var markdown = j2m.to_markdown("{code:javascript}\nvar hello = 'world';\n{code}");
+      markdown.should.eql("```javascript\nvar hello = 'world';\n```");
+    });
 
-  it('should convert code without language-specific and with title into code block', function () {
-    var markdown = j2m.to_markdown("{code:title=Foo.java}\nclass Foo {\n  public static void main() {\n  }\n}\n{code}");
-    markdown.should.eql("```\nclass Foo {\n  public static void main() {\n  }\n}\n```");
-  });
+    it('should convert code without language-specific and with title into code block', function () {
+      var markdown = j2m.to_markdown("{code:title=Foo.java}\nclass Foo {\n  public static void main() {\n  }\n}\n{code}");
+      markdown.should.eql("```\nclass Foo {\n  public static void main() {\n  }\n}\n```");
+    });
 
-  it('should convert fully configured code block', function () {
-    var markdown = j2m.to_markdown(
-      "{code:xml|title=My Title|borderStyle=dashed|borderColor=#ccc|titleBGColor=#F7D6C1|bgColor=#FFFFCE}"
-      + "\n    <test>"
-      + "\n        <another tag=\"attribute\"/>"
-      + "\n    </test>"
-      + "\n{code}");
-    markdown.should.eql(
-      "```xml"
-      + "\n    <test>"
-      + "\n        <another tag=\"attribute\"/>"
-      + "\n    </test>"
-      + "\n```");
-  });
+    it('should convert fully configured code block', function () {
+      var markdown = j2m.to_markdown(
+        "{code:xml|title=My Title|borderStyle=dashed|borderColor=#ccc|titleBGColor=#F7D6C1|bgColor=#FFFFCE}"
+        + "\n    <test>"
+        + "\n        <another tag=\"attribute\"/>"
+        + "\n    </test>"
+        + "\n{code}");
+      markdown.should.eql(
+        "```xml"
+        + "\n    <test>"
+        + "\n        <another tag=\"attribute\"/>"
+        + "\n    </test>"
+        + "\n```");
+    });
 
-  it('should convert multiple codeblocks properly', function () {
-    var markdown = j2m.to_markdown("{code:title=Foo.java}\nclass Foo {\n  public static void main() {\n  }\n}\n{code} \n {code:title=Foo.java}\nclass Foo {\n  public static void main() {\n  }\n}\n{code}");
-    markdown.should.eql("```\nclass Foo {\n  public static void main() {\n  }\n}\n``` \n ```\nclass Foo {\n  public static void main() {\n  }\n}\n```");
+    it('should convert multiple codeblocks properly', function () {
+      var markdown = j2m.to_markdown("{code:title=Foo.java}\nclass Foo {\n  public static void main() {\n  }\n}\n{code} \n {code:title=Foo.java}\nclass Foo {\n  public static void main() {\n  }\n}\n{code}");
+      markdown.should.eql("```\nclass Foo {\n  public static void main() {\n  }\n}\n``` \n ```\nclass Foo {\n  public static void main() {\n  }\n}\n```");
+    });
   });
 
   it('should convert unnamed links properly', function () {
@@ -173,24 +186,21 @@ describe('to_markdown', function () {
     markdown.should.eql("> This is a long blockquote type thingy that needs to be converted.");
   });
 
-  it('should convert un-ordered lists properly', function () {
-    var markdown = j2m.to_markdown("* Foo\n* Bar\n* Baz\n** FooBar\n** BarBaz\n*** FooBarBaz\n* Starting Over");
-    markdown.should.eql("* Foo\n* Bar\n* Baz\n  * FooBar\n  * BarBaz\n    * FooBarBaz\n* Starting Over");
-  });
+  describe('list formatting', function () {
+    it('should convert un-ordered lists properly', function () {
+      var markdown = j2m.to_markdown("* Foo\n* Bar\n* Baz\n** FooBar\n** BarBaz\n*** FooBarBaz\n* Starting Over");
+      markdown.should.eql("* Foo\n* Bar\n* Baz\n  * FooBar\n  * BarBaz\n    * FooBarBaz\n* Starting Over");
+    });
 
-  it('should convert ordered lists properly', function () {
-    var markdown = j2m.to_markdown("# Foo\n# Bar\n# Baz\n## FooBar\n## BarBaz\n### FooBarBaz\n# Starting Over");
-    markdown.should.eql("1. Foo\n1. Bar\n1. Baz\n  1. FooBar\n  1. BarBaz\n    1. FooBarBaz\n1. Starting Over");
-  });
+    it('should convert ordered lists properly', function () {
+      var markdown = j2m.to_markdown("# Foo\n# Bar\n# Baz\n## FooBar\n## BarBaz\n### FooBarBaz\n# Starting Over");
+      markdown.should.eql("1. Foo\n1. Bar\n1. Baz\n  1. FooBar\n  1. BarBaz\n    1. FooBarBaz\n1. Starting Over");
+    });
 
-  it('should handle bold AND italic (combined) correctly', function () {
-    var markdown = j2m.to_markdown("This is _*emphatically bold*_!");
-    markdown.should.eql("This is ***emphatically bold***!");
-  });
-
-  it('should handle bold within a un-ordered list item', function () {
-    var markdown = j2m.to_markdown("* This is not bold!\n** This is *bold*.");
-    markdown.should.eql("* This is not bold!\n  * This is **bold**.");
+    it('should handle bold within a un-ordered list item', function () {
+      var markdown = j2m.to_markdown("* This is not bold!\n** This is *bold*.");
+      markdown.should.eql("* This is not bold!\n  * This is **bold**.");
+    });
   });
 
   it('should be able to handle a complicated multi-line jira-wiki string and convert it to markdown', function () {

--- a/test/jira2md.js
+++ b/test/jira2md.js
@@ -18,6 +18,11 @@ describe('to_markdown', function () {
     markdown.should.eql('**bold words**');
   });
 
+  it("should handle multiple bold sections in a line", function() {
+    var markdown = j2m.to_markdown("*this should be bold* this should not *this should be bold*");
+    markdown.should.eql("**this should be bold** this should not **this should be bold**");
+  });
+
   it("does not perform intraword formatting on asterisks", function() {
     var markdown = j2m.to_markdown("a*phrase*with*asterisks");
     markdown.should.eql("a*phrase*with*asterisks");
@@ -26,6 +31,11 @@ describe('to_markdown', function () {
   it('should convert italics properly', function () {
     var markdown = j2m.to_markdown('_italic_');
     markdown.should.eql('*italic*');
+  });
+
+  it("should handle multiple italic sections in a line", function () {
+    var markdown = j2m.to_markdown("_this should be italic_ this should not _this should be italic_");
+    markdown.should.eql("*this should be italic* this should not *this should be italic*");
   });
 
   it('does not perform intraword formatting on underscores', function () {

--- a/test/jira2md.js
+++ b/test/jira2md.js
@@ -120,11 +120,6 @@ describe('to_markdown', function () {
   });
 
   describe('code block formatting', function () {
-    it('should not apply formatting within codeblocks', function () {
-      var markdown = j2m.to_markdown("{code}\nso *no* further _formatting_ is done here\n{code}");
-      markdown.should.eql("```\nso *no* further _formatting_ is done here\n```");
-    });
-
     it('should convert language-specific code blocks properly', function () {
       var markdown = j2m.to_markdown("{code:javascript}\nvar hello = 'world';\n{code}");
       markdown.should.eql("```javascript\nvar hello = 'world';\n```");
@@ -153,6 +148,11 @@ describe('to_markdown', function () {
     it('should convert multiple codeblocks properly', function () {
       var markdown = j2m.to_markdown("{code:title=Foo.java}\nclass Foo {\n  public static void main() {\n  }\n}\n{code} \n {code:title=Foo.java}\nclass Foo {\n  public static void main() {\n  }\n}\n{code}");
       markdown.should.eql("```\nclass Foo {\n  public static void main() {\n  }\n}\n``` \n ```\nclass Foo {\n  public static void main() {\n  }\n}\n```");
+    });
+
+    it('should not apply formatting within codeblocks', function () {
+      var markdown = j2m.to_markdown("{code}\nso *no* further _formatting_ is done here\n{code}");
+      markdown.should.eql("```\nso *no* further _formatting_ is done here\n```");
     });
   });
 

--- a/test/jira2md.js
+++ b/test/jira2md.js
@@ -143,7 +143,7 @@ describe('to_markdown', function () {
     markdown.should.eql("* This is not bold!\n  * This is **bold**.");
   });
 
-  it.skip('should be able to handle a complicated multi-line jira-wiki string and convert it to markdown', function () {
+  it('should be able to handle a complicated multi-line jira-wiki string and convert it to markdown', function () {
     var jira_str = fs.readFileSync(path.resolve(__dirname, 'test.jira'), "utf8");
     var md_str = fs.readFileSync(path.resolve(__dirname, 'test.md'), "utf8");
     var markdown = j2m.to_markdown(jira_str);

--- a/test/jira2md.js
+++ b/test/jira2md.js
@@ -111,7 +111,7 @@ describe('to_markdown', function() {
         var markdown = j2m.to_markdown("* This is not bold!\n** This is *bold*.");
         markdown.should.eql("* This is not bold!\n  * This is **bold**.");
     });
-    it('should be able to handle a complicated multi-line jira-wiki string and convert it to markdown', function() {
+    it.skip('should be able to handle a complicated multi-line jira-wiki string and convert it to markdown', function() {
         var jira_str = fs.readFileSync(path.resolve(__dirname, 'test.jira'),"utf8");
         var md_str = fs.readFileSync(path.resolve(__dirname, 'test.md'),"utf8");
         var markdown = j2m.to_markdown(jira_str);

--- a/test/jira2md.js
+++ b/test/jira2md.js
@@ -18,14 +18,19 @@ describe('to_markdown', function () {
     markdown.should.eql('**bold words**');
   });
 
-  it('does not perform intraword formatting on underscores', function () {
-    var markdown = j2m.to_markdown('a_phrase_with_underscores');
-    markdown.should.eql('a_phrase_with_underscores');
+  it("does not perform intraword formatting on asterisks", function() {
+    var markdown = j2m.to_markdown("a*phrase*with*asterisks");
+    markdown.should.eql("a*phrase*with*asterisks");
   });
 
   it('should convert italics properly', function () {
     var markdown = j2m.to_markdown('_italic_');
     markdown.should.eql('*italic*');
+  });
+
+  it('does not perform intraword formatting on underscores', function () {
+    var markdown = j2m.to_markdown('a_phrase_with_underscores');
+    markdown.should.eql('a_phrase_with_underscores');
   });
 
   it('should convert monospaced content properly', function () {
@@ -37,6 +42,7 @@ describe('to_markdown', function () {
   //    var markdown = j2m.to_markdown('??citation??');
   //    markdown.should.eql('<cite>citation</cite>');
   //});
+
   it('should convert strikethroughs properly', function () {
     var markdown = j2m.to_markdown('-deleted-');
     markdown.should.eql('~~deleted~~');

--- a/test/jira2md.js
+++ b/test/jira2md.js
@@ -1,5 +1,4 @@
 var should = require('chai').should();
-// var expect = require('chai').expect;
 var fs = require('fs');
 var path = require('path');
 var j2m = require('../index.js');

--- a/test/jira2md.js
+++ b/test/jira2md.js
@@ -75,7 +75,12 @@ describe('to_markdown', function () {
 
   it('should convert preformatted blocks properly', function () {
     var markdown = j2m.to_markdown("{noformat}\nso *no* further _formatting_ is done here\n{noformat}");
-    markdown.should.eql("```\nso **no** further *formatting* is done here\n```");
+    markdown.should.eql("```\nso *no* further _formatting_ is done here\n```");
+  });
+
+  it('should not apply formatting within codeblocks', function () {
+    var markdown = j2m.to_markdown("{code}\nso *no* further _formatting_ is done here\n{code}");
+    markdown.should.eql("```\nso *no* further _formatting_ is done here\n```");
   });
 
   it('should convert language-specific code blocks properly', function () {

--- a/test/jira2md.js
+++ b/test/jira2md.js
@@ -28,6 +28,21 @@ describe('to_markdown', function () {
     markdown.should.eql("a*phrase*with*asterisks");
   });
 
+  it('does not apply bold formatting without an underscore at the end of the phrase', function () {
+    var markdown = j2m.to_markdown('*a*phrase');
+    markdown.should.eql('*a*phrase');
+  });
+
+  it('formats bolds while leaving intraword asterisks untouched', function () {
+    var markdown = j2m.to_markdown('*bold*phrase*with*internal*asterisks*');
+    markdown.should.eql('**bold*phrase*with*internal*asterisks**');
+  });
+
+  it('handles bolds at the end of sentences', function () {
+    var markdown = j2m.to_markdown('A sentence ending in *bold*.');
+    markdown.should.eql('A sentence ending in **bold**.');
+  });
+
   it('should convert italics properly', function () {
     var markdown = j2m.to_markdown('_italic_');
     markdown.should.eql('*italic*');
@@ -41,6 +56,21 @@ describe('to_markdown', function () {
   it('does not perform intraword formatting on underscores', function () {
     var markdown = j2m.to_markdown('a_phrase_with_underscores');
     markdown.should.eql('a_phrase_with_underscores');
+  });
+
+  it('does not apply italic formatting without an underscore at the end of the phrase', function () {
+    var markdown = j2m.to_markdown('_a_phrase');
+    markdown.should.eql('_a_phrase');
+  });
+
+  it('formats italics while leaving intraword underscores untouched', function () {
+    var markdown = j2m.to_markdown('_italic_phrase_with_internal_underscores_');
+    markdown.should.eql('*italic_phrase_with_internal_underscores*');
+  });
+
+  it('handles italics at the end of sentences', function () {
+    var markdown = j2m.to_markdown('A sentence ending in _italic_.');
+    markdown.should.eql('A sentence ending in *italic*.');
   });
 
   it('should convert monospaced content properly', function () {

--- a/test/jira2md.js
+++ b/test/jira2md.js
@@ -64,7 +64,7 @@ describe('to_markdown', function () {
 
   it('should convert code without language-specific and with title into code block', function () {
     var markdown = j2m.to_markdown("{code:title=Foo.java}\nclass Foo {\n  public static void main() {\n  }\n}\n{code}");
-    markdown.should.eql("```\nclass Foo {\n  public static void main() {\n  }\n}\n```")
+    markdown.should.eql("```\nclass Foo {\n  public static void main() {\n  }\n}\n```");
   });
 
   it('should convert fully configured code block', function () {

--- a/test/md2jira.js
+++ b/test/md2jira.js
@@ -132,6 +132,11 @@ describe('to_jira', function () {
       jira.should.eql("{code:javascript}\nvar hello = 'world';\n{code}");
     });
 
+    it('should convert multiple codeblocks properly', function () {
+      var jira = j2m.to_jira("```javascript\nvar hello = 'world';\n``` \n```javascript\nvar hello = 'world';\n```");
+      jira.should.eql("{code:javascript}\nvar hello = 'world';\n{code} \n{code:javascript}\nvar hello = 'world';\n{code}");
+    });
+
     it('should not apply formatting within codeblocks', function () {
       var jira = j2m.to_jira("```\nso **no** further *formatting* _is_ done ***here***\n```");
       jira.should.eql("{code}\nso **no** further *formatting* _is_ done ***here***\n{code}");

--- a/test/md2jira.js
+++ b/test/md2jira.js
@@ -120,7 +120,7 @@ describe('to_jira', function () {
     jira.should.eql("* This is not bold!\n** This is *bold*.");
   });
 
-  it.skip('should be able to handle a complicated multi-line markdown string and convert it to markdown', function () {
+  it('should be able to handle a complicated multi-line markdown string and convert it to markdown', function () {
     var jira_str = fs.readFileSync(path.resolve(__dirname, 'test.jira'), "utf8");
     var md_str = fs.readFileSync(path.resolve(__dirname, 'test.md'), "utf8");
     var jira = j2m.to_jira(md_str);

--- a/test/md2jira.js
+++ b/test/md2jira.js
@@ -20,9 +20,35 @@ describe('to_jira', function () {
         jira.should.eql('*bold words*');
       });
 
+      it("should handle multiple bold sections in a line", function () {
+        var jira = j2m.to_jira("**this should be bold** this should not **this should be bold**");
+        jira.should.eql("*this should be bold* this should not *this should be bold*");
+      });
+
       it("does not perform intraword formatting on asterisks", function () {
         var jira = j2m.to_jira("a*phrase*with*asterisks");
         jira.should.eql("a*phrase*with*asterisks");
+      });
+
+      it('handles bolds at the end of sentences', function () {
+        var jira = j2m.to_jira('A sentence ending in **bold**.');
+        jira.should.eql('A sentence ending in *bold*.');
+      });
+
+      it('formats bolds while leaving intraword asterisks untouched', function () {
+        var jira = j2m.to_jira('**bold*phrase*with*internal*asterisks**');
+        jira.should.eql('*bold*phrase*with*internal*asterisks*');
+      });
+
+      // TODO: Fix the code so this test can ne unskipped
+      it.skip('does not apply bold formatting without an asterisk pair at the start of the phrase', function () {
+        var jira = j2m.to_jira('a**phrase**');
+        jira.should.eql('a**phrase**');
+      });
+
+      it('does not apply bold formatting without an asterisk pair at the end of the phrase', function () {
+        var jira = j2m.to_jira('**a**phrase');
+        jira.should.eql('**a**phrase');
       });
     })
 
@@ -36,11 +62,37 @@ describe('to_jira', function () {
         var jira = j2m.to_jira("a_phrase_with_underscores");
         jira.should.eql("a_phrase_with_underscores");
       });
+
+      it('formats italics while leaving intraword underscores untouched', function () {
+        var jira = j2m.to_jira('_italic_phrase_with_internal_underscores_');
+        jira.should.eql('_italic_phrase_with_internal_underscores_');
+      });
+
+      it('handles italics at the end of sentences', function () {
+        var jira = j2m.to_jira('A sentence ending in *italic*.');
+        jira.should.eql('A sentence ending in _italic_.');
+      });
+
+      // TODO: Fix the code so this test can ne unskipped
+      it.skip('does not apply italic formatting without asterisks at the start of the phrase', function () {
+        var jira = j2m.to_jira('a*phrase*');
+        jira.should.eql('a*phrase*');
+      });
+
+      it('does not apply italic formatting without asterisks at the end of the phrase', function () {
+        var jira = j2m.to_jira('*a*phrase');
+        jira.should.eql('*a*phrase');
+      });
     })
 
     it('should handle bold AND italic (combined) correctly', function () {
       var jira = j2m.to_jira("This is ***emphatically bold***!");
       jira.should.eql("This is _*emphatically bold*_!");
+    });
+
+    it('handles a bold word followed by an italic word', function () {
+      var jira = j2m.to_jira('**bold** *italic*');
+      jira.should.eql('*bold* _italic_');
     });
   });
 
@@ -74,7 +126,7 @@ describe('to_jira', function () {
     jira.should.eql('~subscript~');
   });
 
-  describe('codeblock formatting', function () {
+  describe.skip('codeblock formatting', function () {
     it('should convert preformatted blocks properly', function () {
       var jira = j2m.to_jira("```\nso *no* further **formatting** is done here\n```");
       jira.should.eql("{code}\nso _no_ further *formatting* is done here\n{code}");

--- a/test/md2jira.js
+++ b/test/md2jira.js
@@ -28,10 +28,10 @@ describe('to_jira', function () {
     jira.should.eql('{{monospaced}}');
   });
 
-  it('should convert citations properly', function () {
-    var jira = j2m.to_jira('<cite>citation</cite>');
-    jira.should.eql('??citation??');
-  });
+  // it('should convert citations properly', function () {
+  //   var jira = j2m.to_jira('<cite>citation</cite>');
+  //   jira.should.eql('??citation??');
+  // });
 
   it('should convert strikethroughs properly', function () {
     var jira = j2m.to_jira('~~deleted~~');

--- a/test/md2jira.js
+++ b/test/md2jira.js
@@ -4,105 +4,127 @@ var fs = require('fs');
 var path = require('path');
 var j2m = require('../index.js');
 
-describe('to_jira', function() {
-    it('should exist', function() {
-    	should.exist(j2m.to_jira);
-    });
-    it('should be a function', function() {
-    	j2m.to_jira.should.be.a('function');
-    });
-    it('should convert bolds properly', function() {
-        var jira = j2m.to_jira('**bold**');
-        jira.should.eql('*bold*');
-    });
-    it('should convert italics properly', function() {
-        var jira = j2m.to_jira('*italic*');
-        jira.should.eql('_italic_');
-    });
-    it('should convert monospaced content properly', function() {
-        var jira = j2m.to_jira('`monospaced`');
-        jira.should.eql('{{monospaced}}');
-    });
-    it('should convert citations properly', function() {
-        var jira = j2m.to_jira('<cite>citation</cite>');
-        jira.should.eql('??citation??');
-    });
-    it('should convert strikethroughs properly', function() {
-        var jira = j2m.to_jira('~~deleted~~');
-        jira.should.eql('-deleted-');
-    });
-    it('should convert inserts properly', function() {
-        var jira = j2m.to_jira('<ins>inserted</ins>');
-        jira.should.eql('+inserted+');
-    });
-    it('should convert superscript properly', function() {
-        var jira = j2m.to_jira('<sup>superscript</sup>');
-        jira.should.eql('^superscript^');
-    });
-    it('should convert subscript properly', function() {
-        var jira = j2m.to_jira('<sub>subscript</sub>');
-        jira.should.eql('~subscript~');
-    });
-    it('should convert preformatted blocks properly', function() {
-        var jira = j2m.to_jira("```\nso *no* further **formatting** is done here\n```");
-        jira.should.eql("{code}\nso _no_ further *formatting* is done here\n{code}");
-    });
-    it('should convert language-specific code blocks properly', function() {
-        var jira = j2m.to_jira("```javascript\nvar hello = 'world';\n```");
-        jira.should.eql("{code:javascript}\nvar hello = 'world';\n{code}");
-    });
-    it('should convert unnamed links properly', function() {
-        var jira = j2m.to_jira("<http://google.com>");
-        jira.should.eql("[http://google.com]");
-    });
-    it('should convert named links properly', function() {
-        var jira = j2m.to_jira("[Google](http://google.com)");
-        jira.should.eql("[Google|http://google.com]");
-    });
-    it('should convert headers properly', function() {
-        var h1 = j2m.to_jira("# Biggest heading");
-        var h2 = j2m.to_jira("## Bigger heading");
-        var h3 = j2m.to_jira("### Big heading");
-        var h4 = j2m.to_jira("#### Normal heading");
-        var h5 = j2m.to_jira("##### Small heading");
-        var h6 = j2m.to_jira("###### Smallest heading");
-        h1.should.eql("h1. Biggest heading");
-        h2.should.eql("h2. Bigger heading");
-        h3.should.eql("h3. Big heading");
-        h4.should.eql("h4. Normal heading");
-        h5.should.eql("h5. Small heading");
-        h6.should.eql("h6. Smallest heading");
-    });
-    it('should convert underline-style headers properly', function() {
-        var h1 = j2m.to_jira("Biggest heading\n=======");
-        var h2 = j2m.to_jira("Bigger heading\n------");
-        h1.should.eql("h1. Biggest heading");
-        h2.should.eql("h2. Bigger heading");
-    });
-    it('should convert blockquotes properly', function() {
-        var jira = j2m.to_jira("> This is a long blockquote type thingy that needs to be converted.");
-        jira.should.eql("bq. This is a long blockquote type thingy that needs to be converted.");
-    });
-    it('should convert un-ordered lists properly', function() {
-        var jira = j2m.to_jira("* Foo\n* Bar\n* Baz\n  * FooBar\n  * BarBaz\n    * FooBarBaz\n* Starting Over");
-        jira.should.eql("* Foo\n* Bar\n* Baz\n** FooBar\n** BarBaz\n*** FooBarBaz\n* Starting Over");
-    });
-    it('should convert ordered lists properly', function() {
-        var jira = j2m.to_jira("1. Foo\n1. Bar\n1. Baz\n  1. FooBar\n  1. BarBaz\n    1. FooBarBaz\n1. Starting Over");
-        jira.should.eql("# Foo\n# Bar\n# Baz\n## FooBar\n## BarBaz\n### FooBarBaz\n# Starting Over");
-    });
-    it('should handle bold AND italic (combined) correctly', function() {
-        var jira = j2m.to_jira("This is ***emphatically bold***!");
-        jira.should.eql("This is _*emphatically bold*_!");
-    });
-    it('should handle bold within a un-ordered list item', function() {
-        var jira = j2m.to_jira("* This is not bold!\n  * This is **bold**.");
-        jira.should.eql("* This is not bold!\n** This is *bold*.");
-    });
-    it.skip('should be able to handle a complicated multi-line markdown string and convert it to markdown', function() {
-        var jira_str = fs.readFileSync(path.resolve(__dirname, 'test.jira'),"utf8");
-        var md_str = fs.readFileSync(path.resolve(__dirname, 'test.md'),"utf8");
-        var jira = j2m.to_jira(md_str);
-        jira.should.eql(jira_str);
-    });
+describe('to_jira', function () {
+  it('should exist', function () {
+    should.exist(j2m.to_jira);
+  });
+
+  it('should be a function', function () {
+    j2m.to_jira.should.be.a('function');
+  });
+
+  it('should convert bolds properly', function () {
+    var jira = j2m.to_jira('**bold**');
+    jira.should.eql('*bold*');
+  });
+
+  it('should convert italics properly', function () {
+    var jira = j2m.to_jira('*italic*');
+    jira.should.eql('_italic_');
+  });
+
+  it('should convert monospaced content properly', function () {
+    var jira = j2m.to_jira('`monospaced`');
+    jira.should.eql('{{monospaced}}');
+  });
+
+  it('should convert citations properly', function () {
+    var jira = j2m.to_jira('<cite>citation</cite>');
+    jira.should.eql('??citation??');
+  });
+
+  it('should convert strikethroughs properly', function () {
+    var jira = j2m.to_jira('~~deleted~~');
+    jira.should.eql('-deleted-');
+  });
+
+  it('should convert inserts properly', function () {
+    var jira = j2m.to_jira('<ins>inserted</ins>');
+    jira.should.eql('+inserted+');
+  });
+
+  it('should convert superscript properly', function () {
+    var jira = j2m.to_jira('<sup>superscript</sup>');
+    jira.should.eql('^superscript^');
+  });
+
+  it('should convert subscript properly', function () {
+    var jira = j2m.to_jira('<sub>subscript</sub>');
+    jira.should.eql('~subscript~');
+  });
+
+  it('should convert preformatted blocks properly', function () {
+    var jira = j2m.to_jira("```\nso *no* further **formatting** is done here\n```");
+    jira.should.eql("{code}\nso _no_ further *formatting* is done here\n{code}");
+  });
+
+  it('should convert language-specific code blocks properly', function () {
+    var jira = j2m.to_jira("```javascript\nvar hello = 'world';\n```");
+    jira.should.eql("{code:javascript}\nvar hello = 'world';\n{code}");
+  });
+
+  it('should convert unnamed links properly', function () {
+    var jira = j2m.to_jira("<http://google.com>");
+    jira.should.eql("[http://google.com]");
+  });
+
+  it('should convert named links properly', function () {
+    var jira = j2m.to_jira("[Google](http://google.com)");
+    jira.should.eql("[Google|http://google.com]");
+  });
+
+  it('should convert headers properly', function () {
+    var h1 = j2m.to_jira("# Biggest heading");
+    var h2 = j2m.to_jira("## Bigger heading");
+    var h3 = j2m.to_jira("### Big heading");
+    var h4 = j2m.to_jira("#### Normal heading");
+    var h5 = j2m.to_jira("##### Small heading");
+    var h6 = j2m.to_jira("###### Smallest heading");
+    h1.should.eql("h1. Biggest heading");
+    h2.should.eql("h2. Bigger heading");
+    h3.should.eql("h3. Big heading");
+    h4.should.eql("h4. Normal heading");
+    h5.should.eql("h5. Small heading");
+    h6.should.eql("h6. Smallest heading");
+  });
+
+  it('should convert underline-style headers properly', function () {
+    var h1 = j2m.to_jira("Biggest heading\n=======");
+    var h2 = j2m.to_jira("Bigger heading\n------");
+    h1.should.eql("h1. Biggest heading");
+    h2.should.eql("h2. Bigger heading");
+  });
+
+  it('should convert blockquotes properly', function () {
+    var jira = j2m.to_jira("> This is a long blockquote type thingy that needs to be converted.");
+    jira.should.eql("bq. This is a long blockquote type thingy that needs to be converted.");
+  });
+
+  it('should convert un-ordered lists properly', function () {
+    var jira = j2m.to_jira("* Foo\n* Bar\n* Baz\n  * FooBar\n  * BarBaz\n    * FooBarBaz\n* Starting Over");
+    jira.should.eql("* Foo\n* Bar\n* Baz\n** FooBar\n** BarBaz\n*** FooBarBaz\n* Starting Over");
+  });
+
+  it('should convert ordered lists properly', function () {
+    var jira = j2m.to_jira("1. Foo\n1. Bar\n1. Baz\n  1. FooBar\n  1. BarBaz\n    1. FooBarBaz\n1. Starting Over");
+    jira.should.eql("# Foo\n# Bar\n# Baz\n## FooBar\n## BarBaz\n### FooBarBaz\n# Starting Over");
+  });
+
+  it('should handle bold AND italic (combined) correctly', function () {
+    var jira = j2m.to_jira("This is ***emphatically bold***!");
+    jira.should.eql("This is _*emphatically bold*_!");
+  });
+
+  it('should handle bold within a un-ordered list item', function () {
+    var jira = j2m.to_jira("* This is not bold!\n  * This is **bold**.");
+    jira.should.eql("* This is not bold!\n** This is *bold*.");
+  });
+
+  it.skip('should be able to handle a complicated multi-line markdown string and convert it to markdown', function () {
+    var jira_str = fs.readFileSync(path.resolve(__dirname, 'test.jira'), "utf8");
+    var md_str = fs.readFileSync(path.resolve(__dirname, 'test.md'), "utf8");
+    var jira = j2m.to_jira(md_str);
+    jira.should.eql(jira_str);
+  });
 });
+

--- a/test/md2jira.js
+++ b/test/md2jira.js
@@ -40,7 +40,7 @@ describe('to_jira', function () {
         jira.should.eql('*bold*phrase*with*internal*asterisks*');
       });
 
-      // TODO: Fix the code so this test can ne unskipped
+      // TODO: Fix the code so this test can be unskipped
       it.skip('does not apply bold formatting without an asterisk pair at the start of the phrase', function () {
         var jira = j2m.to_jira('a**phrase**');
         jira.should.eql('a**phrase**');
@@ -73,7 +73,7 @@ describe('to_jira', function () {
         jira.should.eql('A sentence ending in _italic_.');
       });
 
-      // TODO: Fix the code so this test can ne unskipped
+      // TODO: Fix the code so this test can be unskipped
       it.skip('does not apply italic formatting without asterisks at the start of the phrase', function () {
         var jira = j2m.to_jira('a*phrase*');
         jira.should.eql('a*phrase*');
@@ -126,15 +126,15 @@ describe('to_jira', function () {
     jira.should.eql('~subscript~');
   });
 
-  describe.skip('codeblock formatting', function () {
-    it('should convert preformatted blocks properly', function () {
-      var jira = j2m.to_jira("```\nso *no* further **formatting** is done here\n```");
-      jira.should.eql("{code}\nso _no_ further *formatting* is done here\n{code}");
-    });
-
+  describe('codeblock formatting', function () {
     it('should convert language-specific code blocks properly', function () {
       var jira = j2m.to_jira("```javascript\nvar hello = 'world';\n```");
       jira.should.eql("{code:javascript}\nvar hello = 'world';\n{code}");
+    });
+
+    it('should not apply formatting within codeblocks', function () {
+      var jira = j2m.to_jira("```\nso **no** further *formatting* _is_ done ***here***\n```");
+      jira.should.eql("{code}\nso **no** further *formatting* _is_ done ***here***\n{code}");
     });
   });
 

--- a/test/md2jira.js
+++ b/test/md2jira.js
@@ -198,5 +198,10 @@ describe('to_jira', function () {
     var jira = j2m.to_jira(md_str);
     jira.should.eql(jira_str);
   });
+
+  it('should leave urls and emails unchanged', function () {
+    var jira = j2m.to_jira('https://example_url_thing.com some_person@example_domain.com');
+    jira.should.eql('https://example_url_thing.com some_person@example_domain.com');
+  });
 });
 

--- a/test/md2jira.js
+++ b/test/md2jira.js
@@ -13,24 +13,35 @@ describe('to_jira', function () {
     j2m.to_jira.should.be.a('function');
   });
 
-  it('should convert bolds properly', function () {
-    var jira = j2m.to_jira('**bold words**');
-    jira.should.eql('*bold words*');
-  });
+  describe('emphasis formatting', function () {
+    describe('bold formatting', function () {
+      it('should convert bolds properly', function () {
+        var jira = j2m.to_jira('**bold words**');
+        jira.should.eql('*bold words*');
+      });
 
-  it("does not perform intraword formatting on asterisks", function () {
-    var jira = j2m.to_jira("a*phrase*with*asterisks");
-    jira.should.eql("a*phrase*with*asterisks");
-  });
+      it("does not perform intraword formatting on asterisks", function () {
+        var jira = j2m.to_jira("a*phrase*with*asterisks");
+        jira.should.eql("a*phrase*with*asterisks");
+      });
+    })
 
-  it('should convert italics properly', function () {
-    var jira = j2m.to_jira('*italic words*');
-    jira.should.eql('_italic words_');
-  });
+    describe('italic formatting', function () {
+      it('should convert italics properly', function () {
+        var jira = j2m.to_jira('*italic words*');
+        jira.should.eql('_italic words_');
+      });
 
-  it("does not perform intraword formatting on underscores", function() {
-    var jira = j2m.to_jira("a_phrase_with_underscores");
-    jira.should.eql("a_phrase_with_underscores");
+      it("does not perform intraword formatting on underscores", function () {
+        var jira = j2m.to_jira("a_phrase_with_underscores");
+        jira.should.eql("a_phrase_with_underscores");
+      });
+    })
+
+    it('should handle bold AND italic (combined) correctly', function () {
+      var jira = j2m.to_jira("This is ***emphatically bold***!");
+      jira.should.eql("This is _*emphatically bold*_!");
+    });
   });
 
   it('should convert monospaced content properly', function () {
@@ -63,14 +74,16 @@ describe('to_jira', function () {
     jira.should.eql('~subscript~');
   });
 
-  it('should convert preformatted blocks properly', function () {
-    var jira = j2m.to_jira("```\nso *no* further **formatting** is done here\n```");
-    jira.should.eql("{code}\nso _no_ further *formatting* is done here\n{code}");
-  });
+  describe('codeblock formatting', function () {
+    it('should convert preformatted blocks properly', function () {
+      var jira = j2m.to_jira("```\nso *no* further **formatting** is done here\n```");
+      jira.should.eql("{code}\nso _no_ further *formatting* is done here\n{code}");
+    });
 
-  it('should convert language-specific code blocks properly', function () {
-    var jira = j2m.to_jira("```javascript\nvar hello = 'world';\n```");
-    jira.should.eql("{code:javascript}\nvar hello = 'world';\n{code}");
+    it('should convert language-specific code blocks properly', function () {
+      var jira = j2m.to_jira("```javascript\nvar hello = 'world';\n```");
+      jira.should.eql("{code:javascript}\nvar hello = 'world';\n{code}");
+    });
   });
 
   it('should convert unnamed links properly', function () {
@@ -110,24 +123,21 @@ describe('to_jira', function () {
     jira.should.eql("bq. This is a long blockquote type thingy that needs to be converted.");
   });
 
-  it('should convert un-ordered lists properly', function () {
-    var jira = j2m.to_jira("* Foo\n* Bar\n* Baz\n  * FooBar\n  * BarBaz\n    * FooBarBaz\n* Starting Over");
-    jira.should.eql("* Foo\n* Bar\n* Baz\n** FooBar\n** BarBaz\n*** FooBarBaz\n* Starting Over");
-  });
+  describe('list formatting', function () {
+    it('should convert un-ordered lists properly', function () {
+      var jira = j2m.to_jira("* Foo\n* Bar\n* Baz\n  * FooBar\n  * BarBaz\n    * FooBarBaz\n* Starting Over");
+      jira.should.eql("* Foo\n* Bar\n* Baz\n** FooBar\n** BarBaz\n*** FooBarBaz\n* Starting Over");
+    });
 
-  it('should convert ordered lists properly', function () {
-    var jira = j2m.to_jira("1. Foo\n1. Bar\n1. Baz\n  1. FooBar\n  1. BarBaz\n    1. FooBarBaz\n1. Starting Over");
-    jira.should.eql("# Foo\n# Bar\n# Baz\n## FooBar\n## BarBaz\n### FooBarBaz\n# Starting Over");
-  });
+    it('should convert ordered lists properly', function () {
+      var jira = j2m.to_jira("1. Foo\n1. Bar\n1. Baz\n  1. FooBar\n  1. BarBaz\n    1. FooBarBaz\n1. Starting Over");
+      jira.should.eql("# Foo\n# Bar\n# Baz\n## FooBar\n## BarBaz\n### FooBarBaz\n# Starting Over");
+    });
 
-  it('should handle bold AND italic (combined) correctly', function () {
-    var jira = j2m.to_jira("This is ***emphatically bold***!");
-    jira.should.eql("This is _*emphatically bold*_!");
-  });
-
-  it('should handle bold within a un-ordered list item', function () {
-    var jira = j2m.to_jira("* This is not bold!\n  * This is **bold**.");
-    jira.should.eql("* This is not bold!\n** This is *bold*.");
+    it('should handle bold within a un-ordered list item', function () {
+      var jira = j2m.to_jira("* This is not bold!\n  * This is **bold**.");
+      jira.should.eql("* This is not bold!\n** This is *bold*.");
+    });
   });
 
   it('should be able to handle a complicated multi-line markdown string and convert it to markdown', function () {

--- a/test/md2jira.js
+++ b/test/md2jira.js
@@ -14,18 +14,28 @@ describe('to_jira', function () {
   });
 
   it('should convert bolds properly', function () {
-    var jira = j2m.to_jira('**bold**');
-    jira.should.eql('*bold*');
+    var jira = j2m.to_jira('**bold words**');
+    jira.should.eql('*bold words*');
+  });
+
+  it("does not perform intraword formatting on asterisks", function () {
+    var jira = j2m.to_jira("a*phrase*with*asterisks");
+    jira.should.eql("a*phrase*with*asterisks");
   });
 
   it('should convert italics properly', function () {
-    var jira = j2m.to_jira('*italic*');
-    jira.should.eql('_italic_');
+    var jira = j2m.to_jira('*italic words*');
+    jira.should.eql('_italic words_');
+  });
+
+  it("does not perform intraword formatting on underscores", function() {
+    var jira = j2m.to_jira("a_phrase_with_underscores");
+    jira.should.eql("a_phrase_with_underscores");
   });
 
   it('should convert monospaced content properly', function () {
-    var jira = j2m.to_jira('`monospaced`');
-    jira.should.eql('{{monospaced}}');
+    var jira = j2m.to_jira('`monospaced words`');
+    jira.should.eql('{{monospaced words}}');
   });
 
   // it('should convert citations properly', function () {

--- a/test/md2jira.js
+++ b/test/md2jira.js
@@ -99,7 +99,7 @@ describe('to_jira', function() {
         var jira = j2m.to_jira("* This is not bold!\n  * This is **bold**.");
         jira.should.eql("* This is not bold!\n** This is *bold*.");
     });
-    it('should be able to handle a complicated multi-line markdown string and convert it to markdown', function() {
+    it.skip('should be able to handle a complicated multi-line markdown string and convert it to markdown', function() {
         var jira_str = fs.readFileSync(path.resolve(__dirname, 'test.jira'),"utf8");
         var md_str = fs.readFileSync(path.resolve(__dirname, 'test.md'),"utf8");
         var jira = j2m.to_jira(md_str);

--- a/test/test.jira
+++ b/test/test.jira
@@ -12,7 +12,6 @@ h6. Smallest heading
 *strong*
 _emphasis_
 {{monospaced}}
-??citation??
 -deleted-
 +inserted+
 ^superscript^

--- a/test/test.jira
+++ b/test/test.jira
@@ -47,9 +47,10 @@ _*Should be bold AND italic*_
 # Back to first level li
 
 * Here's _italic_ inside li
-* here's *bold* inside li
+* Here's *bold* inside li
+* Here's *bold* and _italic_ inside li
 * Here's _*bold + italic*_ inside li
-** Here they are in one line indented: _italic_ *bold*
+** Here they are in one line indented: _italic_ and *bold*
 
 bq. Here's a long single-paragraph block quote. It should look pretty and stuff.
 

--- a/test/test.md
+++ b/test/test.md
@@ -29,7 +29,7 @@ GitHub Flavor
 
 ```
   preformatted piece of text
-  so *no_ further _formatting* is done here
+  so _no_ further _formatting_ is done here
 ```
 
 ***Should be bold AND italic***

--- a/test/test.md
+++ b/test/test.md
@@ -47,9 +47,10 @@ GitHub Flavor
 1. Back to first level li
 
 * Here's *italic* inside li
-* here's **bold** inside li
+* Here's **bold** inside li
+* Here's **bold** and *italic* inside li
 * Here's ***bold + italic*** inside li
-  * Here they are in one line indented: *italic* **bold**
+  * Here they are in one line indented: *italic* and **bold**
 
 > Here's a long single-paragraph block quote. It should look pretty and stuff.
 

--- a/test/test.md
+++ b/test/test.md
@@ -19,7 +19,7 @@
 
 ```javascript
 var hello = 'world';
-{code}
+```
 
 <http://google.com>
 [Google](http://google.com)
@@ -27,7 +27,7 @@ var hello = 'world';
 GitHub Flavor
 ~~deleted~~
 
-{code}
+```
   preformatted piece of text
   so *no_ further _formatting* is done here
 ```

--- a/test/test.md
+++ b/test/test.md
@@ -12,7 +12,6 @@
 **strong**
 *emphasis*
 `monospaced`
-<cite>citation</cite>
 ~~deleted~~
 <ins>inserted</ins>
 <sup>superscript</sup>


### PR DESCRIPTION
### Description
This PR aims to fix some minor bugs in the [Jira to markdown library](https://github.com/kylefarris/J2M). 

The primary issue addressed in this PR (and the reason for creating this fork) is the issue of intra-word formatting when Jira-flavoured markdown is converted into regular markdown.

**Before Fix**
`phrase_with_underscores` in Jira markdown is transformed to `phrase*with*underscores` in regular markdown. This would then be rendered so:

![image](https://user-images.githubusercontent.com/16496109/51880904-2f479900-23cd-11e9-97ff-8115315ef705.png)


This is not desirable behaviour, particularly for important content such as urls and emails. 

In the other direction, `phrase*with*asterisks` in regular markdown becomes `phrase_with_asterisks` in Jira markdown, which is rendered so:

![image](https://user-images.githubusercontent.com/16496109/51881023-ab41e100-23cd-11e9-999f-370efa0a422b.png)

This is also undesirable. 


**After fix**
This library should recognise the `*` and `_` characters within words should not be transformed. 


#### Other Changes:
- Fixes for broken tests
- Added dependencies
- Small fix for maintaining whitespaces either side of [strikethroughs](https://github.com/karimatthews/J2M/pull/1/commits/dc595d35323f0b332e2497e8eec61b55732296e6)
- Support conversion of multiple codeblocks 
- Prevent formatting being applied within codeblocks and noformat blocks

#### Note

There are two skipped test. My markdown expertise has so far proved insufficient for getting this case to pass. (When a snippet like `a**phrase**` is converted from md to jira it will be formatted to `a*phrase*`.) I think this is acceptable bug to leave for now for two reasons:

1. I can't think of a use case and 
2. This is the current behaviour rather than a new bug

If someone can think of a fix or has a use case that suggests this really needs to be fixed please let me know. 


#### References 

- [Jira Markdown guide](https://confluence.atlassian.com/bitbucketserver/markdown-syntax-guide-776639995.html)


